### PR TITLE
add 'union' types  

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,8 @@ add_executable (CoreBufferTests 3rdparty/catch2/catch.hpp test/parser_tests.cpp 
   test/corebuffer_tests.cpp test/structurecheck_tests.cpp)
 
 add_executable (CoreBufferOutputTests 3rdparty/catch2/catch.hpp test/basetypes.h test/enumtypes.h test/tabletypes.h
-  test/shop.h test/schema.h test/shop_tests.cpp test/schema_tests.cpp test/tabletypes_tests.cpp test/basetype_tests.cpp
-  test/enumtypes_tests.cpp test/corebufferoutput_tests.cpp)
+  test/uniontypes.h test/shop.h test/schema.h test/shop_tests.cpp test/schema_tests.cpp test/tabletypes_tests.cpp
+  test/uniontypes_tests.cpp test/basetype_tests.cpp test/enumtypes_tests.cpp test/corebufferoutput_tests.cpp)
 
 target_link_libraries(CoreBufferC CoreBuffer)
 target_link_libraries(CoreBufferTests CoreBuffer)
@@ -45,6 +45,7 @@ enable_testing()
 add_test(NAME BaseTypeBuild COMMAND $<TARGET_FILE:CoreBufferC> ${PROJECT_SOURCE_DIR}/cor/basetypes.cor ${PROJECT_SOURCE_DIR}/test/basetypes.h)
 add_test(NAME EnumTypesBuild COMMAND $<TARGET_FILE:CoreBufferC> ${PROJECT_SOURCE_DIR}/cor/enumtypes.cor ${PROJECT_SOURCE_DIR}/test/enumtypes.h)
 add_test(NAME TableTypesBuild COMMAND $<TARGET_FILE:CoreBufferC> ${PROJECT_SOURCE_DIR}/cor/tabletypes.cor ${PROJECT_SOURCE_DIR}/test/tabletypes.h)
+add_test(NAME UnionTypesBuild COMMAND $<TARGET_FILE:CoreBufferC> ${PROJECT_SOURCE_DIR}/cor/uniontypes.cor ${PROJECT_SOURCE_DIR}/test/uniontypes.h)
 add_test(NAME ShopExampleBuild COMMAND $<TARGET_FILE:CoreBufferC> ${PROJECT_SOURCE_DIR}/cor/shop.cor ${PROJECT_SOURCE_DIR}/test/shop.h)
 add_test(NAME SchemaBuild COMMAND $<TARGET_FILE:CoreBufferC> ${PROJECT_SOURCE_DIR}/cor/schema.cor ${PROJECT_SOURCE_DIR}/test/schema.h)
 

--- a/cor/schema.cor
+++ b/cor/schema.cor
@@ -26,10 +26,7 @@ table EnumEntry {
 }
 
 table Enum {
-  name:string;
   entries:[EnumEntry];
-
-  init(name);
 }
 
 table Member {
@@ -44,11 +41,29 @@ table Member {
 }
 
 table Table {
-  name:string;
   member:[Member];
   appearance:ui8;
+}
 
-  init(name);
+table Union
+{
+  tables:[string];
+}
+
+table BaseType {
+  isComplex:bool = false;
+
+  init(isComplex);
+}
+
+union Representation { BaseType, Enum, Table, Union }
+
+table Type {
+  name:string;
+  appearance:ui8;
+  representation:Representation;
+
+  init(name, representation);
 }
 
 table Package {
@@ -56,9 +71,7 @@ table Package {
   version:string;
   root_type:string;
 
-  tables:[Table];
-  baseTypes:[Table];
-  enums:[Enum];
+  types:[Type];
 
   init(path, version, root_type);
 }

--- a/cor/uniontypes.cor
+++ b/cor/uniontypes.cor
@@ -25,6 +25,8 @@ table Root {
 
   e:[AB];
 
+  f:AB;
+
   empty:unique AB;
   null:unique AB;
 }

--- a/cor/uniontypes.cor
+++ b/cor/uniontypes.cor
@@ -1,0 +1,20 @@
+package UnionTypes;
+version "0.0";
+root_type Root;
+
+table A {
+  name:string;
+  init(name);
+}
+
+table B {
+  size:i64;
+  init(size);
+}
+
+union AB { A, B }
+
+table Root {
+  a:A;
+  b:B;
+}

--- a/cor/uniontypes.cor
+++ b/cor/uniontypes.cor
@@ -17,4 +17,14 @@ union AB { A, B }
 table Root {
   a:A;
   b:B;
+
+  c:shared AB;
+  cw:weak AB;
+
+  d:unique AB;
+
+  e:[AB];
+
+  empty:unique AB;
+  null:unique AB;
 }

--- a/doc/idl.md
+++ b/doc/idl.md
@@ -107,6 +107,22 @@ types.
 
 Enumerations could not be defined as `root_type`
 
+## Union
+
+**Example:**
+```
+table Mug { /*...*/ }
+table Jar { /*...*/ }
+table Bowl { /*...*/ }
+
+enum Stuff { Mug, Jar, Bowl }
+```
+
+Union types are combination of tables. Theye are one of the defined values *(or undefined)* . There are convenient
+functions created to work with these kind of types.
+
+Union types could not be defined as `root_type`
+
 ## root_type
 
 **Example:**

--- a/src/package.h
+++ b/src/package.h
@@ -109,6 +109,8 @@ struct Union
 
   string name;
   FilePosition location;
+
+  unsigned char appearance{0};
   vector<Attribute> tables;
 };
 

--- a/src/package.h
+++ b/src/package.h
@@ -4,10 +4,12 @@
 #include "fileposition.h"
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 using std::pair;
 using std::string;
+using std::unordered_map;
 using std::vector;
 
 struct Attribute
@@ -101,6 +103,15 @@ struct Table
   FilePosition location;
 };
 
+struct Union
+{
+  explicit Union(const string &n, const FilePosition &fp = FilePosition()) : name(n), location(fp) {}
+
+  string name;
+  FilePosition location;
+  vector<Attribute> tables;
+};
+
 struct Package
 {
   Attribute path;
@@ -109,6 +120,7 @@ struct Package
   vector<Table> tables;
   vector<Table> baseTypes;
   vector<Enum> enums;
+  vector<Union> unions;
 };
 
 #endif  // PACKAGE_H

--- a/src/package.h
+++ b/src/package.h
@@ -114,15 +114,171 @@ struct Union
   vector<Attribute> tables;
 };
 
+struct Type
+{
+  Type() = default;
+  Type(const Type &o) { _clone(o); }
+  Type &operator=(const Type &o)
+  {
+    _destroy();
+    _clone(o);
+    return *this;
+  }
+
+  Type(const Enum &v) : _Enum(new Enum(v)), _selection(_Enum_selection) {}
+  Type(Enum &&v) : _Enum(new Enum(std::forward<Enum>(v))), _selection(_Enum_selection) {}
+  Type &operator=(const Enum &v)
+  {
+    _destroy();
+    _Enum = new Enum(v);
+    _selection = _Enum_selection;
+    return *this;
+  }
+  Type &operator=(Enum &&v)
+  {
+    _destroy();
+    _Enum = new Enum(std::forward<Enum>(v));
+    _selection = _Enum_selection;
+    return *this;
+  }
+
+  Type(const Table &v) : _Table(new Table(v)), _selection(_Table_selection) {}
+  Type(Table &&v) : _Table(new Table(std::forward<Table>(v))), _selection(_Table_selection) {}
+  Type &operator=(const Table &v)
+  {
+    _destroy();
+    _Table = new Table(v);
+    _selection = _Table_selection;
+    return *this;
+  }
+  Type &operator=(Table &&v)
+  {
+    _destroy();
+    _Table = new Table(std::forward<Table>(v));
+    _selection = _Table_selection;
+    return *this;
+  }
+
+  Type(const Union &v) : _Union(new Union(v)), _selection(_Union_selection) {}
+  Type(Union &&v) : _Union(new Union(std::forward<Union>(v))), _selection(_Union_selection) {}
+  Type &operator=(const Union &v)
+  {
+    _destroy();
+    _Union = new Union(v);
+    _selection = _Union_selection;
+    return *this;
+  }
+  Type &operator=(Union &&v)
+  {
+    _destroy();
+    _Union = new Union(std::forward<Union>(v));
+    _selection = _Union_selection;
+    return *this;
+  }
+
+  ~Type() { _destroy(); }
+
+  bool is_Defined() const noexcept { return _selection != no_selection; }
+  void clear() { *this = Type(); }
+
+  bool is_Enum() const noexcept { return _selection == _Enum_selection; }
+  const Enum &as_Enum() const noexcept { return *_Enum; }
+  Enum &as_Enum() { return *_Enum; }
+  template <typename... Args>
+  Enum &create_Enum(Args &&... args)
+  {
+    return (*this = Enum(std::forward<Args>(args)...)).as_Enum();
+  }
+
+  bool is_Table() const noexcept { return _selection == _Table_selection; }
+  const Table &as_Table() const noexcept { return *_Table; }
+  Table &as_Table() { return *_Table; }
+  template <typename... Args>
+  Table &create_Table(Args &&... args)
+  {
+    return (*this = Table(std::forward<Args>(args)...)).as_Table();
+  }
+
+  bool is_Union() const noexcept { return _selection == _Union_selection; }
+  const Union &as_Union() const noexcept { return *_Union; }
+  Union &as_Union() { return *_Union; }
+  template <typename... Args>
+  Union &create_Union(Args &&... args)
+  {
+    return (*this = Union(std::forward<Args>(args)...)).as_Union();
+  }
+
+private:
+  void _clone(const Type &o) noexcept
+  {
+    _selection = o._selection;
+    switch (_selection)
+    {
+      case no_selection:
+        while (false)
+          ; /* hack for coverage tool */
+        break;
+      case _Enum_selection:
+        _Enum = new Enum(*o._Enum);
+        break;
+      case _Table_selection:
+        _Table = new Table(*o._Table);
+        break;
+      case _Union_selection:
+        _Union = new Union(*o._Union);
+        break;
+    }
+  }
+
+  void _destroy() noexcept
+  {
+    switch (_selection)
+    {
+      case no_selection:
+        while (false)
+          ; /* hack for coverage tool */
+        break;
+      case _Enum_selection:
+        delete _Enum;
+        break;
+      case _Table_selection:
+        delete _Table;
+        break;
+      case _Union_selection:
+        delete _Union;
+        break;
+    }
+    no_value = nullptr;
+  }
+
+  union
+  {
+    struct NoValue_t *no_value{nullptr};
+    Enum *_Enum;
+    Table *_Table;
+    Union *_Union;
+  };
+
+  enum Selection_t
+  {
+    no_selection,
+    _Enum_selection,
+    _Table_selection,
+    _Union_selection,
+  };
+
+  Selection_t _selection{no_selection};
+  friend struct Package_io;
+};
+
 struct Package
 {
   Attribute path;
   Attribute version;
   Attribute root_type;
-  vector<Table> tables;
   vector<Table> baseTypes;
-  vector<Enum> enums;
-  vector<Union> unions;
+
+  vector<Type> types;
 };
 
 #endif  // PACKAGE_H

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -260,7 +260,7 @@ bool Parser::readTable()
           return true;
         }))
     {
-      package.tables.push_back(t);
+      package.types.emplace_back(t);
       return true;
     }
   }
@@ -285,7 +285,7 @@ bool Parser::readEnum()
           return true;
         }))
     {
-      package.enums.push_back(e);
+      package.types.emplace_back(e);
       return true;
     }
   }
@@ -310,7 +310,7 @@ bool Parser::readUnion()
           return true;
         }))
     {
-      package.unions.push_back(u);
+      package.types.emplace_back(u);
       return true;
     }
   }
@@ -743,9 +743,9 @@ void Parser::initBaseTypes()
 
 Table *Parser::tableForType(const std::string &name)
 {
-  for (auto &t : package.tables)
-    if (t.name == name)
-      return &t;
+  for (auto &t : package.types)
+    if (t.is_Table() && t.as_Table().name == name)
+      return &t.as_Table();
   for (auto &t : package.baseTypes)
     if (t.name == name)
       return &t;
@@ -754,17 +754,17 @@ Table *Parser::tableForType(const std::string &name)
 
 Union *Parser::unionForType(const std::string &name)
 {
-  for (auto &u : package.unions)
-    if (u.name == name)
-      return &u;
+  for (auto &u : package.types)
+    if (u.is_Union() && u.as_Union().name == name)
+      return &u.as_Union();
   return nullptr;
 }
 
 Enum *Parser::enumForType(const std::string &name)
 {
-  for (auto &e : package.enums)
-    if (e.name == name)
-      return &e;
+  for (auto &e : package.types)
+    if (e.is_Enum() && e.as_Enum().name == name)
+      return &e.as_Enum();
   return nullptr;
 }
 
@@ -793,9 +793,11 @@ void updateAppearance(T *t, const Member &m)
 
 void Parser::updateTableAppearance()
 {
-  for (auto &t : package.tables)
+  for (auto &t : package.types)
   {
-    for (auto &m : t.member)
+    if (!t.is_Table())
+      continue;
+    for (auto &m : t.as_Table().member)
     {
       if (aliases.find(m.type) != aliases.end())
       {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -752,12 +752,43 @@ Table *Parser::tableForType(const std::string &name)
   return nullptr;
 }
 
+Union *Parser::unionForType(const std::string &name)
+{
+  for (auto &u : package.unions)
+    if (u.name == name)
+      return &u;
+  return nullptr;
+}
+
 Enum *Parser::enumForType(const std::string &name)
 {
   for (auto &e : package.enums)
     if (e.name == name)
       return &e;
   return nullptr;
+}
+
+template <class T>
+void updateAppearance(T *t, const Member &m)
+{
+  if (!t)
+    return;
+  if (m.isVector && m.pointer == Pointer::Weak)
+    t->appearance |= WeakVectorAppearance;
+  else if (m.isVector && m.pointer == Pointer::Unique)
+    t->appearance |= UniqueVectorAppearance;
+  else if (m.isVector && m.pointer == Pointer::Shared)
+    t->appearance |= SharedVectorAppearance;
+  else if (m.isVector && m.pointer == Pointer::Plain)
+    t->appearance |= VectorAppearance;
+  else if (!m.isVector && m.pointer == Pointer::Weak)
+    t->appearance |= WeakAppearance;
+  else if (!m.isVector && m.pointer == Pointer::Unique)
+    t->appearance |= UniqueAppearance;
+  else if (!m.isVector && m.pointer == Pointer::Shared)
+    t->appearance |= SharedAppearance;
+  else
+    t->appearance |= PlainAppearance;
 }
 
 void Parser::updateTableAppearance()
@@ -787,25 +818,8 @@ void Parser::updateTableAppearance()
           m.defaultValue.value = fullPackageScope() + e->name + "::" + m.defaultValue.value;
       }
 
-      auto *t = tableForType(m.type);
-      if (!t)
-        continue;
-      if (m.isVector && m.pointer == Pointer::Weak)
-        t->appearance |= WeakVectorAppearance;
-      else if (m.isVector && m.pointer == Pointer::Unique)
-        t->appearance |= UniqueVectorAppearance;
-      else if (m.isVector && m.pointer == Pointer::Shared)
-        t->appearance |= SharedVectorAppearance;
-      else if (m.isVector && m.pointer == Pointer::Plain)
-        t->appearance |= VectorAppearance;
-      else if (!m.isVector && m.pointer == Pointer::Weak)
-        t->appearance |= WeakAppearance;
-      else if (!m.isVector && m.pointer == Pointer::Unique)
-        t->appearance |= UniqueAppearance;
-      else if (!m.isVector && m.pointer == Pointer::Shared)
-        t->appearance |= SharedAppearance;
-      else
-        t->appearance |= PlainAppearance;
+      updateAppearance(tableForType(m.type), m);
+      updateAppearance(unionForType(m.type), m);
     }
   }
 }

--- a/src/parser.h
+++ b/src/parser.h
@@ -75,6 +75,7 @@ private:
 
   void initBaseTypes();
   Table *tableForType(const std::string &t);
+  Union *unionForType(const std::string &t);
   Enum *enumForType(const std::string &t);
   void updateTableAppearance();
   std::string fullPackageScope() const;

--- a/src/parser.h
+++ b/src/parser.h
@@ -49,6 +49,9 @@ private:
   bool readTable();
   bool readEnum();
 
+  bool readUnion();
+  bool readUnionEntries(Union &u);
+
   bool readScopeStatement(const std::function<bool()> &scopeContent);
 
   bool readEnumEntryList(Enum &e, size_t lastValue);

--- a/src/structurecheck.cpp
+++ b/src/structurecheck.cpp
@@ -79,7 +79,7 @@ void StructureCheck::checkDuplicateTableMembers(const Table &t)
 void StructureCheck::checkMemberTypes(const Table &t)
 {
   for (const auto &m : t.member)
-    if (!isBaseType(m.type) && !tableExists(m.type) && !enumExists(m.type))
+    if (!isValidType(m.type))
       _errors.emplace_back("Unknown type '" + m.type + "'.", m.location);
 }
 
@@ -353,6 +353,16 @@ bool StructureCheck::tableExists(const string &name)
 bool StructureCheck::enumExists(const string &name)
 {
   return _enumNames.find(name) != _enumNames.end();
+}
+
+bool StructureCheck::unionExists(const string &name)
+{
+  return _unionNames.find(name) != _unionNames.end();
+}
+
+bool StructureCheck::isValidType(const string &name)
+{
+  return isBaseType(name) || tableExists(name) || unionExists(name) || enumExists(name);
 }
 
 string StructureCheck::methodParameterKey(const Method &m)

--- a/src/structurecheck.h
+++ b/src/structurecheck.h
@@ -57,6 +57,8 @@ private:
   bool isBaseType(const std::string &name);
   bool tableExists(const std::string &name);
   bool enumExists(const std::string &name);
+  bool unionExists(const std::string &name);
+  bool isValidType(const std::string &name);
 
   std::string methodParameterKey(const Method &m);
   std::string methodTypeParameterKey(const Table &t, const Method &m);

--- a/src/structurecheck.h
+++ b/src/structurecheck.h
@@ -9,6 +9,7 @@
 struct Package;
 struct Table;
 struct Enum;
+struct Union;
 struct Method;
 
 class StructureCheck
@@ -22,6 +23,7 @@ private:
   void initNameSets();
   void checkDuplicateTables();
   void checkDuplicateEnums();
+  void checkDuplicateUnions();
 
   void checkTables();
   void checkEmptyTables();
@@ -35,6 +37,11 @@ private:
   void checkEnums();
   void checkEmptyEnums();
   void checkDuplicateEnumEntries(const Enum &e);
+
+  void checkUnions();
+  void checkEmptyUnions();
+  void checkDuplicateUnionEntries(const Union &u);
+  void checkTableReferences(const Union &u);
 
   void checkPackage();
   void checkRootType();
@@ -65,6 +72,7 @@ private:
 
   std::unordered_set<std::string> _tableNames;
   std::unordered_set<std::string> _enumNames;
+  std::unordered_set<std::string> _unionNames;
 };
 
 #endif  // STURCTURECHECK_H

--- a/test/basetypes.h
+++ b/test/basetypes.h
@@ -36,12 +36,60 @@ struct BaseTypes {
   std::string m;
 
   BaseTypes() = default;
+
+  friend bool operator==(const BaseTypes&l, const BaseTypes&r) {
+    return 
+      l.a == r.a
+      && l.aa == r.aa
+      && l.ab == r.ab
+      && l.b == r.b
+      && l.c == r.c
+      && l.d == r.d
+      && l.e == r.e
+      && l.f == r.f
+      && l.g == r.g
+      && l.h == r.h
+      && l.i == r.i
+      && l.j == r.j
+      && l.k == r.k
+      && l.l == r.l
+      && l.m == r.m;
+  }
+
+  friend bool operator!=(const BaseTypes&l, const BaseTypes&r) {
+    return 
+      l.a != r.a
+      || l.aa != r.aa
+      || l.ab != r.ab
+      || l.b != r.b
+      || l.c != r.c
+      || l.d != r.d
+      || l.e != r.e
+      || l.f != r.f
+      || l.g != r.g
+      || l.h != r.h
+      || l.i != r.i
+      || l.j != r.j
+      || l.k != r.k
+      || l.l != r.l
+      || l.m != r.m;
+  }
 };
 
 struct PointerBaseTypes {
   std::vector<std::string> b1;
 
   PointerBaseTypes() = default;
+
+  friend bool operator==(const PointerBaseTypes&l, const PointerBaseTypes&r) {
+    return 
+      l.b1 == r.b1;
+  }
+
+  friend bool operator!=(const PointerBaseTypes&l, const PointerBaseTypes&r) {
+    return 
+      l.b1 != r.b1;
+  }
 };
 
 struct Initializer {
@@ -57,6 +105,20 @@ struct Initializer {
     : a(a_)
     , b(b_)
   {}
+
+  friend bool operator==(const Initializer&l, const Initializer&r) {
+    return 
+      l.a == r.a
+      && l.b == r.b
+      && l.c == r.c;
+  }
+
+  friend bool operator!=(const Initializer&l, const Initializer&r) {
+    return 
+      l.a != r.a
+      || l.b != r.b
+      || l.c != r.c;
+  }
 };
 
 struct Root {
@@ -64,81 +126,19 @@ struct Root {
   PointerBaseTypes b;
 
   Root() = default;
+
+  friend bool operator==(const Root&l, const Root&r) {
+    return 
+      l.a == r.a
+      && l.b == r.b;
+  }
+
+  friend bool operator!=(const Root&l, const Root&r) {
+    return 
+      l.a != r.a
+      || l.b != r.b;
+  }
 };
-
-bool operator==(const BaseTypes&l, const BaseTypes&r) {
-  return 
-    l.a == r.a
-    && l.aa == r.aa
-    && l.ab == r.ab
-    && l.b == r.b
-    && l.c == r.c
-    && l.d == r.d
-    && l.e == r.e
-    && l.f == r.f
-    && l.g == r.g
-    && l.h == r.h
-    && l.i == r.i
-    && l.j == r.j
-    && l.k == r.k
-    && l.l == r.l
-    && l.m == r.m;
-}
-
-bool operator!=(const BaseTypes&l, const BaseTypes&r) {
-  return 
-    l.a != r.a
-    || l.aa != r.aa
-    || l.ab != r.ab
-    || l.b != r.b
-    || l.c != r.c
-    || l.d != r.d
-    || l.e != r.e
-    || l.f != r.f
-    || l.g != r.g
-    || l.h != r.h
-    || l.i != r.i
-    || l.j != r.j
-    || l.k != r.k
-    || l.l != r.l
-    || l.m != r.m;
-}
-
-bool operator==(const PointerBaseTypes&l, const PointerBaseTypes&r) {
-  return 
-    l.b1 == r.b1;
-}
-
-bool operator!=(const PointerBaseTypes&l, const PointerBaseTypes&r) {
-  return 
-    l.b1 != r.b1;
-}
-
-bool operator==(const Initializer&l, const Initializer&r) {
-  return 
-    l.a == r.a
-    && l.b == r.b
-    && l.c == r.c;
-}
-
-bool operator!=(const Initializer&l, const Initializer&r) {
-  return 
-    l.a != r.a
-    || l.b != r.b
-    || l.c != r.c;
-}
-
-bool operator==(const Root&l, const Root&r) {
-  return 
-    l.a == r.a
-    && l.b == r.b;
-}
-
-bool operator!=(const Root&l, const Root&r) {
-  return 
-    l.a != r.a
-    || l.b != r.b;
-}
 
 struct Root_io {
 private:

--- a/test/enumtypes.h
+++ b/test/enumtypes.h
@@ -44,21 +44,21 @@ struct Dummy {
   std::vector<EnumTypes> en3;
 
   Dummy() = default;
+
+  friend bool operator==(const Dummy&l, const Dummy&r) {
+    return 
+      l.en1 == r.en1
+      && l.en2 == r.en2
+      && l.en3 == r.en3;
+  }
+
+  friend bool operator!=(const Dummy&l, const Dummy&r) {
+    return 
+      l.en1 != r.en1
+      || l.en2 != r.en2
+      || l.en3 != r.en3;
+  }
 };
-
-bool operator==(const Dummy&l, const Dummy&r) {
-  return 
-    l.en1 == r.en1
-    && l.en2 == r.en2
-    && l.en3 == r.en3;
-}
-
-bool operator!=(const Dummy&l, const Dummy&r) {
-  return 
-    l.en1 != r.en1
-    || l.en2 != r.en2
-    || l.en3 != r.en3;
-}
 
 inline const std::array<EnumTypes,4> & EnumTypesValues() {
   static const std::array<EnumTypes,4> values {{

--- a/test/enumtypes.h
+++ b/test/enumtypes.h
@@ -22,20 +22,96 @@ enum class EnumTypes : std::int8_t {
   delta = 42,
 };
 
+inline const std::array<EnumTypes,4> & EnumTypesValues() {
+  static const std::array<EnumTypes,4> values {{
+    EnumTypes::alpha,
+    EnumTypes::beta,
+    EnumTypes::gamma,
+    EnumTypes::delta,
+  }};
+  return values;
+};
+
+inline const char * ValueName(const EnumTypes &v) {
+  switch(v) {
+    case EnumTypes::alpha: return "alpha";
+    case EnumTypes::beta: return "beta";
+    case EnumTypes::gamma: return "gamma";
+    case EnumTypes::delta: return "delta";
+  }
+  return "<error>";
+};
+
 enum class Enum16 : std::int16_t {
   a = 512,
+};
+
+inline const std::array<Enum16,1> & Enum16Values() {
+  static const std::array<Enum16,1> values {{
+    Enum16::a,
+  }};
+  return values;
+};
+
+inline const char * ValueName(const Enum16 &v) {
+  switch(v) {
+    case Enum16::a: return "a";
+  }
+  return "<error>";
 };
 
 enum class Enum32 : std::int32_t {
   a = 128000,
 };
 
+inline const std::array<Enum32,1> & Enum32Values() {
+  static const std::array<Enum32,1> values {{
+    Enum32::a,
+  }};
+  return values;
+};
+
+inline const char * ValueName(const Enum32 &v) {
+  switch(v) {
+    case Enum32::a: return "a";
+  }
+  return "<error>";
+};
+
 enum class Enum64 : std::int64_t {
   a = 4294967297,
 };
 
+inline const std::array<Enum64,1> & Enum64Values() {
+  static const std::array<Enum64,1> values {{
+    Enum64::a,
+  }};
+  return values;
+};
+
+inline const char * ValueName(const Enum64 &v) {
+  switch(v) {
+    case Enum64::a: return "a";
+  }
+  return "<error>";
+};
+
 enum class EnumMinus8 : std::int8_t {
   a = -1,
+};
+
+inline const std::array<EnumMinus8,1> & EnumMinus8Values() {
+  static const std::array<EnumMinus8,1> values {{
+    EnumMinus8::a,
+  }};
+  return values;
+};
+
+inline const char * ValueName(const EnumMinus8 &v) {
+  switch(v) {
+    case EnumMinus8::a: return "a";
+  }
+  return "<error>";
 };
 
 struct Dummy {
@@ -58,82 +134,6 @@ struct Dummy {
       || l.en2 != r.en2
       || l.en3 != r.en3;
   }
-};
-
-inline const std::array<EnumTypes,4> & EnumTypesValues() {
-  static const std::array<EnumTypes,4> values {{
-    EnumTypes::alpha,
-    EnumTypes::beta,
-    EnumTypes::gamma,
-    EnumTypes::delta,
-  }};
-  return values;
-};
-
-inline const char * ValueName(const EnumTypes &v) {
-  switch(v) {
-    case EnumTypes::alpha: return "alpha";
-    case EnumTypes::beta: return "beta";
-    case EnumTypes::gamma: return "gamma";
-    case EnumTypes::delta: return "delta";
-  }
-  return "<error>";
-};
-
-inline const std::array<Enum16,1> & Enum16Values() {
-  static const std::array<Enum16,1> values {{
-    Enum16::a,
-  }};
-  return values;
-};
-
-inline const char * ValueName(const Enum16 &v) {
-  switch(v) {
-    case Enum16::a: return "a";
-  }
-  return "<error>";
-};
-
-inline const std::array<Enum32,1> & Enum32Values() {
-  static const std::array<Enum32,1> values {{
-    Enum32::a,
-  }};
-  return values;
-};
-
-inline const char * ValueName(const Enum32 &v) {
-  switch(v) {
-    case Enum32::a: return "a";
-  }
-  return "<error>";
-};
-
-inline const std::array<Enum64,1> & Enum64Values() {
-  static const std::array<Enum64,1> values {{
-    Enum64::a,
-  }};
-  return values;
-};
-
-inline const char * ValueName(const Enum64 &v) {
-  switch(v) {
-    case Enum64::a: return "a";
-  }
-  return "<error>";
-};
-
-inline const std::array<EnumMinus8,1> & EnumMinus8Values() {
-  static const std::array<EnumMinus8,1> values {{
-    EnumMinus8::a,
-  }};
-  return values;
-};
-
-inline const char * ValueName(const EnumMinus8 &v) {
-  switch(v) {
-    case EnumMinus8::a: return "a";
-  }
-  return "<error>";
 };
 
 struct Dummy_io {

--- a/test/parser_error_tests.cpp
+++ b/test/parser_error_tests.cpp
@@ -155,4 +155,10 @@ TEST_CASE("Parsing idls with error", "[parsing, error, syntax]")
                  "table T1 {\n"
                  "  a:string=\"..as.;}");
   }
+
+  SECTION("union tables")
+  {
+    checkThrowIn("Expected union name after 'union'.", 1, 6, "union {}");
+    checkThrowIn("Missing closing '}'.", 1, 14, "union Dummy { ,}");
+  }
 }

--- a/test/parser_tests.cpp
+++ b/test/parser_tests.cpp
@@ -20,12 +20,12 @@ root_type BaseTypes;
 table BaseTypes {)" + member +
                        "\n}");
 
-  REQUIRE((p.tables.size() == 1 && p.tables.front().member.size() == 1));
-  CHECK(p.tables.front().member[0].isBaseType);
-  CHECK_FALSE(p.tables.front().member[0].isVector);
-  CHECK(p.tables.front().member[0].pointer == Pointer::Plain);
-  CHECK(p.tables.front().member[0].type == type);
-  CHECK(p.tables.front().member[0].defaultValue.value == defValue);
+  REQUIRE((p.types.size() == 1 && p.types.front().is_Table() && p.types.front().as_Table().member.size() == 1));
+  CHECK(p.types.front().as_Table().member[0].isBaseType);
+  CHECK_FALSE(p.types.front().as_Table().member[0].isVector);
+  CHECK(p.types.front().as_Table().member[0].pointer == Pointer::Plain);
+  CHECK(p.types.front().as_Table().member[0].type == type);
+  CHECK(p.types.front().as_Table().member[0].defaultValue.value == defValue);
 }
 
 TEST_CASE("Parsing packages", "[parser]")
@@ -61,76 +61,80 @@ enum Access { Private, Public = 3, Protected }
 
     SECTION("Checking parsed enum")
     {
-      REQUIRE(p.enums.size() == 1);
-      CHECK(p.enums.front().name == "Access");
+      REQUIRE((p.types.size() == 3 && p.types.back().is_Enum()));
+      CHECK(p.types.back().as_Enum().name == "Access");
 
-      REQUIRE(p.enums.front().entries.size() == 3);
-      CHECK(p.enums.front().entries[0].name == "Private");
-      CHECK(p.enums.front().entries[0].value == 0);
-      CHECK(p.enums.front().entries[1].name == "Public");
-      CHECK(p.enums.front().entries[1].value == 3);
-      CHECK(p.enums.front().entries[2].name == "Protected");
-      CHECK(p.enums.front().entries[2].value == 4);
+      REQUIRE(p.types.back().as_Enum().entries.size() == 3);
+      CHECK(p.types.back().as_Enum().entries[0].name == "Private");
+      CHECK(p.types.back().as_Enum().entries[0].value == 0);
+      CHECK(p.types.back().as_Enum().entries[1].name == "Public");
+      CHECK(p.types.back().as_Enum().entries[1].value == 3);
+      CHECK(p.types.back().as_Enum().entries[2].name == "Protected");
+      CHECK(p.types.back().as_Enum().entries[2].value == 4);
     }
 
     SECTION("Checking parsed XXX")
     {
-      REQUIRE(p.tables.size() == 2);
+      REQUIRE(p.types.size() == 3);
+      REQUIRE(p.types[0].is_Table());
+      REQUIRE(p.types[1].is_Table());
 
-      CHECK(p.tables[0].name == "XXX");
+      CHECK(p.types[0].as_Table().name == "XXX");
 
-      REQUIRE(p.tables[0].member.size() == 4);
+      REQUIRE(p.types[0].as_Table().member.size() == 4);
 
-      CHECK(p.tables[0].member[0].isBaseType);
-      CHECK(!p.tables[0].member[0].isVector);
-      CHECK(p.tables[0].member[0].name == "bill");
-      CHECK(p.tables[0].member[0].type == "std::int32_t");
-      CHECK(p.tables[0].member[0].defaultValue.value == "1");
-      CHECK(p.tables[0].member[0].pointer == Pointer::Plain);
+      CHECK(p.types[0].as_Table().member[0].isBaseType);
+      CHECK(!p.types[0].as_Table().member[0].isVector);
+      CHECK(p.types[0].as_Table().member[0].name == "bill");
+      CHECK(p.types[0].as_Table().member[0].type == "std::int32_t");
+      CHECK(p.types[0].as_Table().member[0].defaultValue.value == "1");
+      CHECK(p.types[0].as_Table().member[0].pointer == Pointer::Plain);
 
-      CHECK(!p.tables[0].member[1].isVector);
-      CHECK(p.tables[0].member[1].isBaseType);
-      CHECK(p.tables[0].member[1].name == "aul");
-      CHECK(p.tables[0].member[1].type == "bool");
-      CHECK(p.tables[0].member[1].defaultValue.value == "false");
-      CHECK(p.tables[0].member[1].pointer == Pointer::Plain);
+      CHECK(!p.types[0].as_Table().member[1].isVector);
+      CHECK(p.types[0].as_Table().member[1].isBaseType);
+      CHECK(p.types[0].as_Table().member[1].name == "aul");
+      CHECK(p.types[0].as_Table().member[1].type == "bool");
+      CHECK(p.types[0].as_Table().member[1].defaultValue.value == "false");
+      CHECK(p.types[0].as_Table().member[1].pointer == Pointer::Plain);
 
-      CHECK(!p.tables[0].member[2].isVector);
-      CHECK(p.tables[0].member[2].isBaseType);
-      CHECK(p.tables[0].member[2].name == "kaul");
-      CHECK(p.tables[0].member[2].type == "float");
-      CHECK(p.tables[0].member[2].defaultValue.value == "0.0f");
-      CHECK(p.tables[0].member[2].pointer == Pointer::Plain);
+      CHECK(!p.types[0].as_Table().member[2].isVector);
+      CHECK(p.types[0].as_Table().member[2].isBaseType);
+      CHECK(p.types[0].as_Table().member[2].name == "kaul");
+      CHECK(p.types[0].as_Table().member[2].type == "float");
+      CHECK(p.types[0].as_Table().member[2].defaultValue.value == "0.0f");
+      CHECK(p.types[0].as_Table().member[2].pointer == Pointer::Plain);
 
-      CHECK(p.tables[0].member[3].isVector);
-      CHECK(p.tables[0].member[3].isBaseType);
-      CHECK(p.tables[0].member[3].name == "baul");
-      CHECK(p.tables[0].member[3].type == "float");
-      CHECK(p.tables[0].member[3].defaultValue.value.empty());
-      CHECK(p.tables[0].member[3].pointer == Pointer::Plain);
+      CHECK(p.types[0].as_Table().member[3].isVector);
+      CHECK(p.types[0].as_Table().member[3].isBaseType);
+      CHECK(p.types[0].as_Table().member[3].name == "baul");
+      CHECK(p.types[0].as_Table().member[3].type == "float");
+      CHECK(p.types[0].as_Table().member[3].defaultValue.value.empty());
+      CHECK(p.types[0].as_Table().member[3].pointer == Pointer::Plain);
     }
 
     SECTION("Checking parsed XXX")
     {
-      REQUIRE(p.tables.size() == 2);
+      REQUIRE(p.types.size() == 3);
+      REQUIRE(p.types[0].is_Table());
+      REQUIRE(p.types[1].is_Table());
 
-      CHECK(p.tables[1].name == "YYY");
+      CHECK(p.types[1].as_Table().name == "YYY");
 
-      REQUIRE(p.tables[1].member.size() == 2);
+      REQUIRE(p.types[1].as_Table().member.size() == 2);
 
-      CHECK(!p.tables[1].member[0].isVector);
-      CHECK(!p.tables[1].member[0].isBaseType);
-      CHECK(p.tables[1].member[0].name == "still");
-      CHECK(p.tables[1].member[0].type == "XXX");
-      CHECK(p.tables[1].member[0].defaultValue.value.empty());
-      CHECK(p.tables[1].member[0].pointer == Pointer::Unique);
+      CHECK(!p.types[1].as_Table().member[0].isVector);
+      CHECK(!p.types[1].as_Table().member[0].isBaseType);
+      CHECK(p.types[1].as_Table().member[0].name == "still");
+      CHECK(p.types[1].as_Table().member[0].type == "XXX");
+      CHECK(p.types[1].as_Table().member[0].defaultValue.value.empty());
+      CHECK(p.types[1].as_Table().member[0].pointer == Pointer::Unique);
 
-      CHECK(p.tables[1].member[1].isVector);
-      CHECK(!p.tables[1].member[1].isBaseType);
-      CHECK(p.tables[1].member[1].name == "sub");
-      CHECK(p.tables[1].member[1].type == "YYY");
-      CHECK(p.tables[1].member[1].defaultValue.value.empty());
-      CHECK(p.tables[1].member[1].pointer == Pointer::Shared);
+      CHECK(p.types[1].as_Table().member[1].isVector);
+      CHECK(!p.types[1].as_Table().member[1].isBaseType);
+      CHECK(p.types[1].as_Table().member[1].name == "sub");
+      CHECK(p.types[1].as_Table().member[1].type == "YYY");
+      CHECK(p.types[1].as_Table().member[1].defaultValue.value.empty());
+      CHECK(p.types[1].as_Table().member[1].pointer == Pointer::Shared);
     }
   }
 
@@ -191,16 +195,16 @@ table PointerTypes {
   c:weak Test;
 })");
 
-    REQUIRE((p.tables.size() == 2 && p.tables.back().member.size() == 3));
+    REQUIRE((p.types.size() == 2 && p.types.back().is_Table() && p.types.back().as_Table().member.size() == 3));
 
-    CHECK(!p.tables.back().member[0].isBaseType);
-    CHECK(p.tables.back().member[0].pointer == Pointer::Unique);
+    CHECK(!p.types.back().as_Table().member[0].isBaseType);
+    CHECK(p.types.back().as_Table().member[0].pointer == Pointer::Unique);
 
-    CHECK(!p.tables.back().member[1].isBaseType);
-    CHECK(p.tables.back().member[1].pointer == Pointer::Shared);
+    CHECK(!p.types.back().as_Table().member[1].isBaseType);
+    CHECK(p.types.back().as_Table().member[1].pointer == Pointer::Shared);
 
-    CHECK(!p.tables.back().member[2].isBaseType);
-    CHECK(p.tables.back().member[2].pointer == Pointer::Weak);
+    CHECK(!p.types.back().as_Table().member[2].isBaseType);
+    CHECK(p.types.back().as_Table().member[2].pointer == Pointer::Weak);
   }
 
   SECTION("Vector types")
@@ -219,23 +223,23 @@ table VectorTypes {
   d:[float];
 })");
 
-    REQUIRE((p.tables.size() == 2 && p.tables.back().member.size() == 4));
+    REQUIRE((p.types.size() == 2 && p.types.back().is_Table() && p.types.back().as_Table().member.size() == 4));
 
-    CHECK(!p.tables.back().member[0].isBaseType);
-    CHECK(p.tables.back().member[0].isVector);
-    CHECK(p.tables.back().member[0].pointer == Pointer::Unique);
+    CHECK(!p.types.back().as_Table().member[0].isBaseType);
+    CHECK(p.types.back().as_Table().member[0].isVector);
+    CHECK(p.types.back().as_Table().member[0].pointer == Pointer::Unique);
 
-    CHECK(!p.tables.back().member[1].isBaseType);
-    CHECK(p.tables.back().member[1].isVector);
-    CHECK(p.tables.back().member[1].pointer == Pointer::Shared);
+    CHECK(!p.types.back().as_Table().member[1].isBaseType);
+    CHECK(p.types.back().as_Table().member[1].isVector);
+    CHECK(p.types.back().as_Table().member[1].pointer == Pointer::Shared);
 
-    CHECK(!p.tables.back().member[2].isBaseType);
-    CHECK(p.tables.back().member[2].isVector);
-    CHECK(p.tables.back().member[2].pointer == Pointer::Weak);
+    CHECK(!p.types.back().as_Table().member[2].isBaseType);
+    CHECK(p.types.back().as_Table().member[2].isVector);
+    CHECK(p.types.back().as_Table().member[2].pointer == Pointer::Weak);
 
-    CHECK(p.tables.back().member[3].isBaseType);
-    CHECK(p.tables.back().member[3].isVector);
-    CHECK(p.tables.back().member[3].pointer == Pointer::Plain);
+    CHECK(p.types.back().as_Table().member[3].isBaseType);
+    CHECK(p.types.back().as_Table().member[3].isVector);
+    CHECK(p.types.back().as_Table().member[3].pointer == Pointer::Plain);
   }
 
   SECTION("Enums as member")
@@ -251,8 +255,8 @@ table VectorTypes {
   a:Test;
 })");
 
-    CHECK((p.enums.size() == 1 && p.enums.back().entries.size() == 3));
-    CHECK((p.tables.size() == 1 && p.tables.back().member.size() == 1));
+    CHECK((p.types.size() == 2 && p.types.front().is_Enum() && p.types.front().as_Enum().entries.size() == 3));
+    CHECK((p.types.size() == 2 && p.types.back().is_Table() && p.types.back().as_Table().member.size() == 1));
   }
 
   SECTION("default values for enums")
@@ -270,11 +274,11 @@ table Dummy
   en2:EnumTypes=delta;
 })");
 
-    REQUIRE((p.enums.size() == 1 && p.enums.back().entries.size() == 4));
-    REQUIRE((p.tables.size() == 1 && p.tables.back().member.size() == 2));
+    REQUIRE((p.types.size() == 2 && p.types.front().is_Enum() && p.types.front().as_Enum().entries.size() == 4));
+    REQUIRE((p.types.size() == 2 && p.types.back().is_Table() && p.types.back().as_Table().member.size() == 2));
 
-    CHECK(p.tables[0].member[0].defaultValue.value == "Scope::Sub::EnumTypes::alpha");
-    CHECK(p.tables[0].member[1].defaultValue.value == "Scope::Sub::EnumTypes::delta");
+    CHECK(p.types[1].as_Table().member[0].defaultValue.value == "Scope::Sub::EnumTypes::alpha");
+    CHECK(p.types[1].as_Table().member[1].defaultValue.value == "Scope::Sub::EnumTypes::delta");
   }
 
   SECTION("default values for enums without package")
@@ -291,11 +295,11 @@ table Dummy
   en2:EnumTypes=delta;
 })");
 
-    REQUIRE((p.enums.size() == 1 && p.enums.back().entries.size() == 4));
-    REQUIRE((p.tables.size() == 1 && p.tables.back().member.size() == 2));
+    REQUIRE((p.types.size() == 2 && p.types.front().is_Enum() && p.types.front().as_Enum().entries.size() == 4));
+    REQUIRE((p.types.size() == 2 && p.types.back().is_Table() && p.types.back().as_Table().member.size() == 2));
 
-    CHECK(p.tables[0].member[0].defaultValue.value == "EnumTypes::alpha");
-    CHECK(p.tables[0].member[1].defaultValue.value == "EnumTypes::delta");
+    CHECK(p.types[1].as_Table().member[0].defaultValue.value == "EnumTypes::alpha");
+    CHECK(p.types[1].as_Table().member[1].defaultValue.value == "EnumTypes::delta");
   }
 
   SECTION("empty table or enum")
@@ -342,19 +346,19 @@ table Dummy
           "  init();\n"
           "}");
 
-      REQUIRE(p.tables.size() == 1);
+      REQUIRE((p.types.size() == 1 && p.types[0].is_Table()));
 
-      REQUIRE(p.tables[0].methods.size() == 3);
-      CHECK(p.tables[0].methods[0].name == "init");
-      CHECK(p.tables[0].methods[1].name == "init");
-      CHECK(p.tables[0].methods[2].name == "init");
+      REQUIRE(p.types[0].as_Table().methods.size() == 3);
+      CHECK(p.types[0].as_Table().methods[0].name == "init");
+      CHECK(p.types[0].as_Table().methods[1].name == "init");
+      CHECK(p.types[0].as_Table().methods[2].name == "init");
 
-      REQUIRE(p.tables[0].methods[0].parameter.size() == 2);
-      CHECK(p.tables[0].methods[0].parameter[0].name == "a");
-      CHECK(p.tables[0].methods[0].parameter[1].name == "b");
+      REQUIRE(p.types[0].as_Table().methods[0].parameter.size() == 2);
+      CHECK(p.types[0].as_Table().methods[0].parameter[0].name == "a");
+      CHECK(p.types[0].as_Table().methods[0].parameter[1].name == "b");
 
-      CHECK(p.tables[0].methods[1].parameter.size() == 1);
-      CHECK(p.tables[0].methods[2].parameter.empty());
+      CHECK(p.types[0].as_Table().methods[1].parameter.size() == 1);
+      CHECK(p.types[0].as_Table().methods[2].parameter.empty());
     }
   }
 
@@ -371,12 +375,12 @@ table Dummy
     SECTION("parsing content test")
     {
       const auto p = parse("union U { A, B }\n");
-      REQUIRE(p.unions.size() == 1);
-      CHECK(p.unions[0].name == "U");
+      REQUIRE((p.types.size() == 1 && p.types[0].is_Union()));
+      CHECK(p.types[0].as_Union().name == "U");
 
-      REQUIRE(p.unions[0].tables.size() == 2);
-      CHECK(p.unions[0].tables[0].value == "A");
-      CHECK(p.unions[0].tables[1].value == "B");
+      REQUIRE(p.types[0].as_Union().tables.size() == 2);
+      CHECK(p.types[0].as_Union().tables[0].value == "A");
+      CHECK(p.types[0].as_Union().tables[1].value == "B");
     }
   }
 }

--- a/test/parser_tests.cpp
+++ b/test/parser_tests.cpp
@@ -341,6 +341,42 @@ table Dummy
           "  init(b);\n"
           "  init();\n"
           "}");
+
+      REQUIRE(p.tables.size() == 1);
+
+      REQUIRE(p.tables[0].methods.size() == 3);
+      CHECK(p.tables[0].methods[0].name == "init");
+      CHECK(p.tables[0].methods[1].name == "init");
+      CHECK(p.tables[0].methods[2].name == "init");
+
+      REQUIRE(p.tables[0].methods[0].parameter.size() == 2);
+      CHECK(p.tables[0].methods[0].parameter[0].name == "a");
+      CHECK(p.tables[0].methods[0].parameter[1].name == "b");
+
+      CHECK(p.tables[0].methods[1].parameter.size() == 1);
+      CHECK(p.tables[0].methods[2].parameter.empty());
+    }
+  }
+
+  SECTION("union tables")
+  {
+    SECTION("basic parsing")
+    {
+      parse("union U { }\n");
+      parse("union U { A}\n");
+      parse("union U { A, B }\n");
+      parse("union U { A, B, }\n");
+    }
+
+    SECTION("parsing content test")
+    {
+      const auto p = parse("union U { A, B }\n");
+      REQUIRE(p.unions.size() == 1);
+      CHECK(p.unions[0].name == "U");
+
+      REQUIRE(p.unions[0].tables.size() == 2);
+      CHECK(p.unions[0].tables[0].value == "A");
+      CHECK(p.unions[0].tables[1].value == "B");
     }
   }
 }

--- a/test/schema.h
+++ b/test/schema.h
@@ -26,6 +26,26 @@ enum class Pointer : std::int8_t {
   Shared = 3,
 };
 
+inline const std::array<Pointer,4> & PointerValues() {
+  static const std::array<Pointer,4> values {{
+    Pointer::Plain,
+    Pointer::Weak,
+    Pointer::Unique,
+    Pointer::Shared,
+  }};
+  return values;
+};
+
+inline const char * ValueName(const Pointer &v) {
+  switch(v) {
+    case Pointer::Plain: return "Plain";
+    case Pointer::Weak: return "Weak";
+    case Pointer::Unique: return "Unique";
+    case Pointer::Shared: return "Shared";
+  }
+  return "<error>";
+};
+
 enum class PointerAppearance : std::int8_t {
   NoPointer = 0,
   WeakAppearance = 1,
@@ -36,6 +56,36 @@ enum class PointerAppearance : std::int8_t {
   UniqueVectorAppearance = 6,
   SharedVectorAppearance = 7,
   PlainAppearance = 8,
+};
+
+inline const std::array<PointerAppearance,9> & PointerAppearanceValues() {
+  static const std::array<PointerAppearance,9> values {{
+    PointerAppearance::NoPointer,
+    PointerAppearance::WeakAppearance,
+    PointerAppearance::UniqueAppearance,
+    PointerAppearance::SharedAppearance,
+    PointerAppearance::VectorAppearance,
+    PointerAppearance::WeakVectorAppearance,
+    PointerAppearance::UniqueVectorAppearance,
+    PointerAppearance::SharedVectorAppearance,
+    PointerAppearance::PlainAppearance,
+  }};
+  return values;
+};
+
+inline const char * ValueName(const PointerAppearance &v) {
+  switch(v) {
+    case PointerAppearance::NoPointer: return "NoPointer";
+    case PointerAppearance::WeakAppearance: return "WeakAppearance";
+    case PointerAppearance::UniqueAppearance: return "UniqueAppearance";
+    case PointerAppearance::SharedAppearance: return "SharedAppearance";
+    case PointerAppearance::VectorAppearance: return "VectorAppearance";
+    case PointerAppearance::WeakVectorAppearance: return "WeakVectorAppearance";
+    case PointerAppearance::UniqueVectorAppearance: return "UniqueVectorAppearance";
+    case PointerAppearance::SharedVectorAppearance: return "SharedVectorAppearance";
+    case PointerAppearance::PlainAppearance: return "PlainAppearance";
+  }
+  return "<error>";
 };
 
 struct EnumEntry {
@@ -177,56 +227,6 @@ struct Package {
       || l.baseTypes != r.baseTypes
       || l.enums != r.enums;
   }
-};
-
-inline const std::array<Pointer,4> & PointerValues() {
-  static const std::array<Pointer,4> values {{
-    Pointer::Plain,
-    Pointer::Weak,
-    Pointer::Unique,
-    Pointer::Shared,
-  }};
-  return values;
-};
-
-inline const char * ValueName(const Pointer &v) {
-  switch(v) {
-    case Pointer::Plain: return "Plain";
-    case Pointer::Weak: return "Weak";
-    case Pointer::Unique: return "Unique";
-    case Pointer::Shared: return "Shared";
-  }
-  return "<error>";
-};
-
-inline const std::array<PointerAppearance,9> & PointerAppearanceValues() {
-  static const std::array<PointerAppearance,9> values {{
-    PointerAppearance::NoPointer,
-    PointerAppearance::WeakAppearance,
-    PointerAppearance::UniqueAppearance,
-    PointerAppearance::SharedAppearance,
-    PointerAppearance::VectorAppearance,
-    PointerAppearance::WeakVectorAppearance,
-    PointerAppearance::UniqueVectorAppearance,
-    PointerAppearance::SharedVectorAppearance,
-    PointerAppearance::PlainAppearance,
-  }};
-  return values;
-};
-
-inline const char * ValueName(const PointerAppearance &v) {
-  switch(v) {
-    case PointerAppearance::NoPointer: return "NoPointer";
-    case PointerAppearance::WeakAppearance: return "WeakAppearance";
-    case PointerAppearance::UniqueAppearance: return "UniqueAppearance";
-    case PointerAppearance::SharedAppearance: return "SharedAppearance";
-    case PointerAppearance::VectorAppearance: return "VectorAppearance";
-    case PointerAppearance::WeakVectorAppearance: return "WeakVectorAppearance";
-    case PointerAppearance::UniqueVectorAppearance: return "UniqueVectorAppearance";
-    case PointerAppearance::SharedVectorAppearance: return "SharedVectorAppearance";
-    case PointerAppearance::PlainAppearance: return "PlainAppearance";
-  }
-  return "<error>";
 };
 
 struct Package_io {

--- a/test/schema.h
+++ b/test/schema.h
@@ -47,6 +47,18 @@ struct EnumEntry {
     : name(name_)
     , value(value_)
   {}
+
+  friend bool operator==(const EnumEntry&l, const EnumEntry&r) {
+    return 
+      l.name == r.name
+      && l.value == r.value;
+  }
+
+  friend bool operator!=(const EnumEntry&l, const EnumEntry&r) {
+    return 
+      l.name != r.name
+      || l.value != r.value;
+  }
 };
 
 struct Enum {
@@ -57,6 +69,18 @@ struct Enum {
   Enum(const std::string &name_)
     : name(name_)
   {}
+
+  friend bool operator==(const Enum&l, const Enum&r) {
+    return 
+      l.name == r.name
+      && l.entries == r.entries;
+  }
+
+  friend bool operator!=(const Enum&l, const Enum&r) {
+    return 
+      l.name != r.name
+      || l.entries != r.entries;
+  }
 };
 
 struct Member {
@@ -72,6 +96,26 @@ struct Member {
     : name(name_)
     , type(type_)
   {}
+
+  friend bool operator==(const Member&l, const Member&r) {
+    return 
+      l.name == r.name
+      && l.type == r.type
+      && l.defaultValue == r.defaultValue
+      && l.isVector == r.isVector
+      && l.isBaseType == r.isBaseType
+      && l.pointer == r.pointer;
+  }
+
+  friend bool operator!=(const Member&l, const Member&r) {
+    return 
+      l.name != r.name
+      || l.type != r.type
+      || l.defaultValue != r.defaultValue
+      || l.isVector != r.isVector
+      || l.isBaseType != r.isBaseType
+      || l.pointer != r.pointer;
+  }
 };
 
 struct Table {
@@ -83,6 +127,20 @@ struct Table {
   Table(const std::string &name_)
     : name(name_)
   {}
+
+  friend bool operator==(const Table&l, const Table&r) {
+    return 
+      l.name == r.name
+      && l.member == r.member
+      && l.appearance == r.appearance;
+  }
+
+  friend bool operator!=(const Table&l, const Table&r) {
+    return 
+      l.name != r.name
+      || l.member != r.member
+      || l.appearance != r.appearance;
+  }
 };
 
 struct Package {
@@ -99,85 +157,27 @@ struct Package {
     , version(version_)
     , root_type(root_type_)
   {}
+
+  friend bool operator==(const Package&l, const Package&r) {
+    return 
+      l.path == r.path
+      && l.version == r.version
+      && l.root_type == r.root_type
+      && l.tables == r.tables
+      && l.baseTypes == r.baseTypes
+      && l.enums == r.enums;
+  }
+
+  friend bool operator!=(const Package&l, const Package&r) {
+    return 
+      l.path != r.path
+      || l.version != r.version
+      || l.root_type != r.root_type
+      || l.tables != r.tables
+      || l.baseTypes != r.baseTypes
+      || l.enums != r.enums;
+  }
 };
-
-bool operator==(const EnumEntry&l, const EnumEntry&r) {
-  return 
-    l.name == r.name
-    && l.value == r.value;
-}
-
-bool operator!=(const EnumEntry&l, const EnumEntry&r) {
-  return 
-    l.name != r.name
-    || l.value != r.value;
-}
-
-bool operator==(const Enum&l, const Enum&r) {
-  return 
-    l.name == r.name
-    && l.entries == r.entries;
-}
-
-bool operator!=(const Enum&l, const Enum&r) {
-  return 
-    l.name != r.name
-    || l.entries != r.entries;
-}
-
-bool operator==(const Member&l, const Member&r) {
-  return 
-    l.name == r.name
-    && l.type == r.type
-    && l.defaultValue == r.defaultValue
-    && l.isVector == r.isVector
-    && l.isBaseType == r.isBaseType
-    && l.pointer == r.pointer;
-}
-
-bool operator!=(const Member&l, const Member&r) {
-  return 
-    l.name != r.name
-    || l.type != r.type
-    || l.defaultValue != r.defaultValue
-    || l.isVector != r.isVector
-    || l.isBaseType != r.isBaseType
-    || l.pointer != r.pointer;
-}
-
-bool operator==(const Table&l, const Table&r) {
-  return 
-    l.name == r.name
-    && l.member == r.member
-    && l.appearance == r.appearance;
-}
-
-bool operator!=(const Table&l, const Table&r) {
-  return 
-    l.name != r.name
-    || l.member != r.member
-    || l.appearance != r.appearance;
-}
-
-bool operator==(const Package&l, const Package&r) {
-  return 
-    l.path == r.path
-    && l.version == r.version
-    && l.root_type == r.root_type
-    && l.tables == r.tables
-    && l.baseTypes == r.baseTypes
-    && l.enums == r.enums;
-}
-
-bool operator!=(const Package&l, const Package&r) {
-  return 
-    l.path != r.path
-    || l.version != r.version
-    || l.root_type != r.root_type
-    || l.tables != r.tables
-    || l.baseTypes != r.baseTypes
-    || l.enums != r.enums;
-}
 
 inline const std::array<Pointer,4> & PointerValues() {
   static const std::array<Pointer,4> values {{

--- a/test/schema.h
+++ b/test/schema.h
@@ -17,6 +17,10 @@ struct EnumEntry;
 struct Enum;
 struct Member;
 struct Table;
+struct Union;
+struct BaseType;
+struct Representation;
+struct Type;
 struct Package;
 
 enum class Pointer : std::int8_t {
@@ -112,24 +116,18 @@ struct EnumEntry {
 };
 
 struct Enum {
-  std::string name;
   std::vector<EnumEntry> entries;
 
   Enum() = default;
-  Enum(const std::string &name_)
-    : name(name_)
-  {}
 
   friend bool operator==(const Enum&l, const Enum&r) {
     return 
-      l.name == r.name
-      && l.entries == r.entries;
+      l.entries == r.entries;
   }
 
   friend bool operator!=(const Enum&l, const Enum&r) {
     return 
-      l.name != r.name
-      || l.entries != r.entries;
+      l.entries != r.entries;
   }
 };
 
@@ -169,27 +167,302 @@ struct Member {
 };
 
 struct Table {
-  std::string name;
   std::vector<Member> member;
   std::uint8_t appearance{0u};
 
   Table() = default;
-  Table(const std::string &name_)
-    : name(name_)
-  {}
 
   friend bool operator==(const Table&l, const Table&r) {
     return 
-      l.name == r.name
-      && l.member == r.member
+      l.member == r.member
       && l.appearance == r.appearance;
   }
 
   friend bool operator!=(const Table&l, const Table&r) {
     return 
-      l.name != r.name
-      || l.member != r.member
+      l.member != r.member
       || l.appearance != r.appearance;
+  }
+};
+
+struct Union {
+  std::vector<std::string> tables;
+
+  Union() = default;
+
+  friend bool operator==(const Union&l, const Union&r) {
+    return 
+      l.tables == r.tables;
+  }
+
+  friend bool operator!=(const Union&l, const Union&r) {
+    return 
+      l.tables != r.tables;
+  }
+};
+
+struct BaseType {
+  bool isComplex{false};
+
+  BaseType() = default;
+  BaseType(const bool &isComplex_)
+    : isComplex(isComplex_)
+  {}
+
+  friend bool operator==(const BaseType&l, const BaseType&r) {
+    return 
+      l.isComplex == r.isComplex;
+  }
+
+  friend bool operator!=(const BaseType&l, const BaseType&r) {
+    return 
+      l.isComplex != r.isComplex;
+  }
+};
+
+struct Representation {
+  Representation() = default;
+  Representation(const Representation &o) { _clone(o); }
+  Representation& operator=(const Representation &o) { _destroy(); _clone(o); return *this; }
+
+  Representation(const BaseType &v)
+    : _BaseType(new BaseType(v))
+    , _selection(_BaseType_selection)
+  {}
+  Representation(BaseType &&v)
+    : _BaseType(new BaseType(std::forward<BaseType>(v)))
+    , _selection(_BaseType_selection)
+  {}
+  Representation & operator=(const BaseType &v) {
+    _destroy();
+    _BaseType = new BaseType(v);
+    _selection = _BaseType_selection;
+    return *this;
+  }
+  Representation & operator=(BaseType &&v) {
+    _destroy();
+    _BaseType = new BaseType(std::forward<BaseType>(v));
+    _selection = _BaseType_selection;
+    return *this;
+  }
+
+  Representation(const Enum &v)
+    : _Enum(new Enum(v))
+    , _selection(_Enum_selection)
+  {}
+  Representation(Enum &&v)
+    : _Enum(new Enum(std::forward<Enum>(v)))
+    , _selection(_Enum_selection)
+  {}
+  Representation & operator=(const Enum &v) {
+    _destroy();
+    _Enum = new Enum(v);
+    _selection = _Enum_selection;
+    return *this;
+  }
+  Representation & operator=(Enum &&v) {
+    _destroy();
+    _Enum = new Enum(std::forward<Enum>(v));
+    _selection = _Enum_selection;
+    return *this;
+  }
+
+  Representation(const Table &v)
+    : _Table(new Table(v))
+    , _selection(_Table_selection)
+  {}
+  Representation(Table &&v)
+    : _Table(new Table(std::forward<Table>(v)))
+    , _selection(_Table_selection)
+  {}
+  Representation & operator=(const Table &v) {
+    _destroy();
+    _Table = new Table(v);
+    _selection = _Table_selection;
+    return *this;
+  }
+  Representation & operator=(Table &&v) {
+    _destroy();
+    _Table = new Table(std::forward<Table>(v));
+    _selection = _Table_selection;
+    return *this;
+  }
+
+  Representation(const Union &v)
+    : _Union(new Union(v))
+    , _selection(_Union_selection)
+  {}
+  Representation(Union &&v)
+    : _Union(new Union(std::forward<Union>(v)))
+    , _selection(_Union_selection)
+  {}
+  Representation & operator=(const Union &v) {
+    _destroy();
+    _Union = new Union(v);
+    _selection = _Union_selection;
+    return *this;
+  }
+  Representation & operator=(Union &&v) {
+    _destroy();
+    _Union = new Union(std::forward<Union>(v));
+    _selection = _Union_selection;
+    return *this;
+  }
+
+  ~Representation() {
+    _destroy();
+  }
+
+  bool is_Defined() const noexcept { return _selection != no_selection; }
+  void clear() { *this = Representation(); }
+
+  bool is_BaseType() const noexcept { return _selection == _BaseType_selection; }
+  const BaseType & as_BaseType() const noexcept { return *_BaseType; }
+  BaseType & as_BaseType() { return *_BaseType; }
+  template<typename... Args> BaseType & create_BaseType(Args&&... args) {
+    return (*this = BaseType(std::forward<Args>(args)...)).as_BaseType();
+  }
+
+  bool is_Enum() const noexcept { return _selection == _Enum_selection; }
+  const Enum & as_Enum() const noexcept { return *_Enum; }
+  Enum & as_Enum() { return *_Enum; }
+  template<typename... Args> Enum & create_Enum(Args&&... args) {
+    return (*this = Enum(std::forward<Args>(args)...)).as_Enum();
+  }
+
+  bool is_Table() const noexcept { return _selection == _Table_selection; }
+  const Table & as_Table() const noexcept { return *_Table; }
+  Table & as_Table() { return *_Table; }
+  template<typename... Args> Table & create_Table(Args&&... args) {
+    return (*this = Table(std::forward<Args>(args)...)).as_Table();
+  }
+
+  bool is_Union() const noexcept { return _selection == _Union_selection; }
+  const Union & as_Union() const noexcept { return *_Union; }
+  Union & as_Union() { return *_Union; }
+  template<typename... Args> Union & create_Union(Args&&... args) {
+    return (*this = Union(std::forward<Args>(args)...)).as_Union();
+  }
+
+  friend bool operator==(const Representation&ab, const BaseType &o) noexcept  { return ab.is_BaseType() && ab.as_BaseType() == o; }
+  friend bool operator==(const BaseType &o, const Representation&ab) noexcept  { return ab.is_BaseType() && o == ab.as_BaseType(); }
+  friend bool operator!=(const Representation&ab, const BaseType &o) noexcept  { return !ab.is_BaseType() || ab.as_BaseType() != o; }
+  friend bool operator!=(const BaseType &o, const Representation&ab) noexcept  { return !ab.is_BaseType() || o != ab.as_BaseType(); }
+
+  friend bool operator==(const Representation&ab, const Enum &o) noexcept  { return ab.is_Enum() && ab.as_Enum() == o; }
+  friend bool operator==(const Enum &o, const Representation&ab) noexcept  { return ab.is_Enum() && o == ab.as_Enum(); }
+  friend bool operator!=(const Representation&ab, const Enum &o) noexcept  { return !ab.is_Enum() || ab.as_Enum() != o; }
+  friend bool operator!=(const Enum &o, const Representation&ab) noexcept  { return !ab.is_Enum() || o != ab.as_Enum(); }
+
+  friend bool operator==(const Representation&ab, const Table &o) noexcept  { return ab.is_Table() && ab.as_Table() == o; }
+  friend bool operator==(const Table &o, const Representation&ab) noexcept  { return ab.is_Table() && o == ab.as_Table(); }
+  friend bool operator!=(const Representation&ab, const Table &o) noexcept  { return !ab.is_Table() || ab.as_Table() != o; }
+  friend bool operator!=(const Table &o, const Representation&ab) noexcept  { return !ab.is_Table() || o != ab.as_Table(); }
+
+  friend bool operator==(const Representation&ab, const Union &o) noexcept  { return ab.is_Union() && ab.as_Union() == o; }
+  friend bool operator==(const Union &o, const Representation&ab) noexcept  { return ab.is_Union() && o == ab.as_Union(); }
+  friend bool operator!=(const Representation&ab, const Union &o) noexcept  { return !ab.is_Union() || ab.as_Union() != o; }
+  friend bool operator!=(const Union &o, const Representation&ab) noexcept  { return !ab.is_Union() || o != ab.as_Union(); }
+
+  bool operator==(const Representation &o) const noexcept
+  {
+    if (this == &o)
+      return true;
+    if (_selection != o._selection)
+      return false;
+    switch(_selection) {
+    case no_selection: while(false); /* hack for coverage tool */ return true;
+    case _BaseType_selection: return *_BaseType == *o._BaseType;
+    case _Enum_selection: return *_Enum == *o._Enum;
+    case _Table_selection: return *_Table == *o._Table;
+    case _Union_selection: return *_Union == *o._Union;
+    }
+    return false; // without this line there is a msvc warning I do not understand.
+  }
+
+  bool operator!=(const Representation &o) const noexcept
+  {
+    if (this == &o)
+      return false;
+    if (_selection != o._selection)
+      return true;
+    switch(_selection) {
+    case no_selection: while(false); /* hack for coverage tool */ return false;
+    case _BaseType_selection: return *_BaseType != *o._BaseType;
+    case _Enum_selection: return *_Enum != *o._Enum;
+    case _Table_selection: return *_Table != *o._Table;
+    case _Union_selection: return *_Union != *o._Union;
+    }
+    return false; // without this line there is a msvc warning I do not understand.
+  }
+
+private:
+  void _clone(const Representation &o) noexcept
+  {
+     _selection = o._selection;
+    switch(_selection) {
+    case no_selection: while(false); /* hack for coverage tool */ break;
+    case _BaseType_selection: _BaseType = new BaseType(*o._BaseType); break;
+    case _Enum_selection: _Enum = new Enum(*o._Enum); break;
+    case _Table_selection: _Table = new Table(*o._Table); break;
+    case _Union_selection: _Union = new Union(*o._Union); break;
+    }
+  }
+
+  void _destroy() noexcept {
+    switch(_selection) {
+    case no_selection: while(false); /* hack for coverage tool */ break;
+    case _BaseType_selection: delete _BaseType; break;
+    case _Enum_selection: delete _Enum; break;
+    case _Table_selection: delete _Table; break;
+    case _Union_selection: delete _Union; break;
+    }
+    no_value = nullptr;
+  }
+
+  union {
+    struct NoValue_t *no_value{nullptr};
+    BaseType * _BaseType;
+    Enum * _Enum;
+    Table * _Table;
+    Union * _Union;
+  };
+
+  enum Selection_t {
+    no_selection,
+    _BaseType_selection,
+    _Enum_selection,
+    _Table_selection,
+    _Union_selection,
+  };
+
+  Selection_t _selection{no_selection};
+  friend struct Package_io;
+};
+
+struct Type {
+  std::string name;
+  std::uint8_t appearance{0u};
+  Representation representation;
+
+  Type() = default;
+  Type(const std::string &name_, const Representation &representation_)
+    : name(name_)
+    , representation(representation_)
+  {}
+
+  friend bool operator==(const Type&l, const Type&r) {
+    return 
+      l.name == r.name
+      && l.appearance == r.appearance
+      && l.representation == r.representation;
+  }
+
+  friend bool operator!=(const Type&l, const Type&r) {
+    return 
+      l.name != r.name
+      || l.appearance != r.appearance
+      || l.representation != r.representation;
   }
 };
 
@@ -197,9 +470,7 @@ struct Package {
   std::string path;
   std::string version;
   std::string root_type;
-  std::vector<Table> tables;
-  std::vector<Table> baseTypes;
-  std::vector<Enum> enums;
+  std::vector<Type> types;
 
   Package() = default;
   Package(const std::string &path_, const std::string &version_, const std::string &root_type_)
@@ -213,9 +484,7 @@ struct Package {
       l.path == r.path
       && l.version == r.version
       && l.root_type == r.root_type
-      && l.tables == r.tables
-      && l.baseTypes == r.baseTypes
-      && l.enums == r.enums;
+      && l.types == r.types;
   }
 
   friend bool operator!=(const Package&l, const Package&r) {
@@ -223,9 +492,7 @@ struct Package {
       l.path != r.path
       || l.version != r.version
       || l.root_type != r.root_type
-      || l.tables != r.tables
-      || l.baseTypes != r.baseTypes
-      || l.enums != r.enums;
+      || l.types != r.types;
   }
 };
 
@@ -242,6 +509,12 @@ private:
   template<typename T> void Write(std::ostream &o, const std::vector<T> &v) {
     Write(o, v.size());
     o.write(reinterpret_cast<const char *>(v.data()), sizeof(T) * v.size());
+  }
+
+  void Write(std::ostream &o, const std::vector<std::string> &v) {
+    Write(o, v.size());
+    for (const auto &entry : v)
+      Write(o, entry);
   }
 
   template<typename T> void Write(std::ostream &, const std::shared_ptr<T> &) {
@@ -266,6 +539,14 @@ private:
     Read(i, s);
     v.resize(s);
     i.read(reinterpret_cast<char *>(v.data()), sizeof(T) * s);
+  }
+
+  void Read(std::istream &i, std::vector<std::string> &v) {
+    auto size = v.size();
+    Read(i, size);
+    v.resize(size);
+    for (auto &entry : v)
+      Read(i, entry);
   }
 
   void Read(std::istream &i, std::string &v) {
@@ -300,27 +581,11 @@ private:
   }
 
   void Write(std::ostream &o, const Enum &v) {
-    Write(o, v.name);
     Write(o, v.entries);
   }
 
-  void Write(std::ostream &o, const std::vector<Enum> &v) {
-    Write(o, v.size());
-    for (const auto &entry : v)
-      Write(o, entry);
-  }
-
   void Read(std::istream &s, Enum &v) {
-    Read(s, v.name);
     Read(s, v.entries);
-  }
-
-  void Read(std::istream &s, std::vector<Enum> &v) {
-    auto size = v.size();
-    Read(s, size);
-    v.resize(size);
-    for (auto &entry : v)
-      Read(s, entry);
   }
 
   void Write(std::ostream &o, const Member &v) {
@@ -356,24 +621,72 @@ private:
   }
 
   void Write(std::ostream &o, const Table &v) {
-    Write(o, v.name);
     Write(o, v.member);
     Write(o, v.appearance);
   }
 
-  void Write(std::ostream &o, const std::vector<Table> &v) {
+  void Read(std::istream &s, Table &v) {
+    Read(s, v.member);
+    Read(s, v.appearance);
+  }
+
+  void Write(std::ostream &o, const Union &v) {
+    Write(o, v.tables);
+  }
+
+  void Read(std::istream &s, Union &v) {
+    Read(s, v.tables);
+  }
+
+  void Write(std::ostream &o, const BaseType &v) {
+    Write(o, v.isComplex);
+  }
+
+  void Read(std::istream &s, BaseType &v) {
+    Read(s, v.isComplex);
+  }
+
+  void Write(std::ostream &o, const Representation &v) {
+    o.write(reinterpret_cast<const char*>(&v._selection), sizeof(Representation::Selection_t));
+    switch(v._selection) {
+    case Representation::no_selection: while(false); /* hack for coverage tool */ break;
+    case Representation::_BaseType_selection: Write(o, v.as_BaseType()); break;
+    case Representation::_Enum_selection: Write(o, v.as_Enum()); break;
+    case Representation::_Table_selection: Write(o, v.as_Table()); break;
+    case Representation::_Union_selection: Write(o, v.as_Union()); break;
+    }
+  }
+
+  void Read(std::istream &i, Representation &v) {
+    i.read(reinterpret_cast<char*>(&v._selection), sizeof(Representation::Selection_t));
+    switch(v._selection) {
+    case Representation::no_selection: while(false); /* hack for coverage tool */ break;
+    case Representation::_BaseType_selection: Read(i, v.create_BaseType()); break;
+    case Representation::_Enum_selection: Read(i, v.create_Enum()); break;
+    case Representation::_Table_selection: Read(i, v.create_Table()); break;
+    case Representation::_Union_selection: Read(i, v.create_Union()); break;
+    }
+  }
+
+  void Write(std::ostream &o, const Type &v) {
+    Write(o, v.name);
+    Write(o, v.appearance);
+    Write(o, v.representation);
+  }
+
+  void Write(std::ostream &o, const std::vector<Type> &v) {
     Write(o, v.size());
     for (const auto &entry : v)
       Write(o, entry);
   }
 
-  void Read(std::istream &s, Table &v) {
+  void Read(std::istream &s, Type &v) {
     Read(s, v.name);
-    Read(s, v.member);
     Read(s, v.appearance);
+    Read(s, v.representation);
   }
 
-  void Read(std::istream &s, std::vector<Table> &v) {
+  void Read(std::istream &s, std::vector<Type> &v) {
     auto size = v.size();
     Read(s, size);
     v.resize(size);
@@ -385,18 +698,14 @@ private:
     Write(o, v.path);
     Write(o, v.version);
     Write(o, v.root_type);
-    Write(o, v.tables);
-    Write(o, v.baseTypes);
-    Write(o, v.enums);
+    Write(o, v.types);
   }
 
   void Read(std::istream &s, Package &v) {
     Read(s, v.path);
     Read(s, v.version);
     Read(s, v.root_type);
-    Read(s, v.tables);
-    Read(s, v.baseTypes);
-    Read(s, v.enums);
+    Read(s, v.types);
   }
 
 public:

--- a/test/schema_tests.cpp
+++ b/test/schema_tests.cpp
@@ -24,22 +24,31 @@ TEST_CASE("Schema output test", "[output]")
 
     CHECK(Package() == Package());
     CHECK_FALSE(Package() != Package());
+
+    CHECK(Type() == Type());
+    CHECK_FALSE(Type() != Type());
   }
 
   SECTION("reading whats written")
   {
-    Enum e1("E1");
+    Package p("Scope", "0.1", "P1");
+
+    Enum e1;
     e1.entries.emplace_back("x", 42);
     e1.entries.emplace_back("half", 21);
+    p.types.emplace_back("E1", e1);
 
-    Table t1("T1");
+    Table t1;
     t1.member.emplace_back("e", "E1");
     t1.member.emplace_back("x", "std::uint32_t");
+    p.types.emplace_back("T1", t1);
 
-    Package p("Scope", "0.1", "T1");
-    p.tables.emplace_back(t1);
-    p.baseTypes.emplace_back("base_type");
-    p.enums.emplace_back(e1);
+    p.types.emplace_back("base_type", BaseType(true));
+
+    Union u;
+    u.tables.emplace_back("X1");
+    u.tables.emplace_back("X2");
+    p.types.emplace_back("U1", u);
 
     Package cIn;
     CHECK_FALSE(p == cIn);
@@ -53,6 +62,7 @@ TEST_CASE("Schema output test", "[output]")
     Package_io().ReadPackage(sIn, cIn);
 
     CHECK(p == cIn);
+    CHECK_FALSE(p != cIn);
   }
 
   SECTION("Reading fails with wrong data")

--- a/test/shop.h
+++ b/test/shop.h
@@ -25,6 +25,18 @@ struct Item {
 
   Item() = default;
 
+  friend bool operator==(const Item&l, const Item&r) {
+    return 
+      l.name == r.name
+      && l.price == r.price;
+  }
+
+  friend bool operator!=(const Item&l, const Item&r) {
+    return 
+      l.name != r.name
+      || l.price != r.price;
+  }
+
 private:
   unsigned int io_counter_{0};
   friend struct Shop_io;
@@ -36,6 +48,18 @@ struct Customer {
 
   Customer() = default;
 
+  friend bool operator==(const Customer&l, const Customer&r) {
+    return 
+      l.name == r.name
+      && l.address == r.address;
+  }
+
+  friend bool operator!=(const Customer&l, const Customer&r) {
+    return 
+      l.name != r.name
+      || l.address != r.address;
+  }
+
 private:
   unsigned int io_counter_{0};
   friend struct Shop_io;
@@ -46,6 +70,18 @@ struct Order {
   std::shared_ptr<Customer> customer;
 
   Order() = default;
+
+  friend bool operator==(const Order&l, const Order&r) {
+    return 
+      l.items == r.items
+      && l.customer == r.customer;
+  }
+
+  friend bool operator!=(const Order&l, const Order&r) {
+    return 
+      l.items != r.items
+      || l.customer != r.customer;
+  }
 };
 
 struct Shop {
@@ -54,57 +90,21 @@ struct Shop {
   std::vector<Order> orders;
 
   Shop() = default;
+
+  friend bool operator==(const Shop&l, const Shop&r) {
+    return 
+      l.items == r.items
+      && l.customers == r.customers
+      && l.orders == r.orders;
+  }
+
+  friend bool operator!=(const Shop&l, const Shop&r) {
+    return 
+      l.items != r.items
+      || l.customers != r.customers
+      || l.orders != r.orders;
+  }
 };
-
-bool operator==(const Item&l, const Item&r) {
-  return 
-    l.name == r.name
-    && l.price == r.price;
-}
-
-bool operator!=(const Item&l, const Item&r) {
-  return 
-    l.name != r.name
-    || l.price != r.price;
-}
-
-bool operator==(const Customer&l, const Customer&r) {
-  return 
-    l.name == r.name
-    && l.address == r.address;
-}
-
-bool operator!=(const Customer&l, const Customer&r) {
-  return 
-    l.name != r.name
-    || l.address != r.address;
-}
-
-bool operator==(const Order&l, const Order&r) {
-  return 
-    l.items == r.items
-    && l.customer == r.customer;
-}
-
-bool operator!=(const Order&l, const Order&r) {
-  return 
-    l.items != r.items
-    || l.customer != r.customer;
-}
-
-bool operator==(const Shop&l, const Shop&r) {
-  return 
-    l.items == r.items
-    && l.customers == r.customers
-    && l.orders == r.orders;
-}
-
-bool operator!=(const Shop&l, const Shop&r) {
-  return 
-    l.items != r.items
-    || l.customers != r.customers
-    || l.orders != r.orders;
-}
 
 struct Shop_io {
 private:

--- a/test/structurecheck_tests.cpp
+++ b/test/structurecheck_tests.cpp
@@ -193,25 +193,39 @@ TEST_CASE("Check structure errors", "[error, parsing, structure]")
     }
   }
 
-  SECTION("wrong union definitions")
+  SECTION("union definitions")
   {
-    checkErrorIn("union 'U1' already defined.", 3, 2,
-                 "union U1 { Dummy }\n"
-                 "union U2 { Dummy }\n"
-                 " union U1 { Dummy }\n");
-    checkErrorIn("union 'U1' already defined.", 3, 2,
-                 "table U1 { c:int; }\n"
-                 "union U2 { Dummy }\n"
-                 " union U1 { Dummy }\n");
-    checkErrorIn("union 'U1' already defined.", 3, 2,
-                 "enum U1 { c }\n"
-                 "union U2 { Dummy }\n"
-                 " union U1 { Dummy }\n");
-    checkErrorIn("Empty union 'U2'.", 1, 4, "   union U2 {}");
-    checkErrorIn("union entry 'B' already defined for 'U2'.", 2, 19,
-                 "table B{a:int;}\n"
-                 "union U2 {B,Dummy,B}");
-    checkErrorIn("Unknown table 'xxx'.", 1, 11, "union T1 {xxx, Dummy}");
+    SECTION("declaration errors")
+    {
+      checkErrorIn("union 'U1' already defined.", 3, 2,
+                   "union U1 { Dummy }\n"
+                   "union U2 { Dummy }\n"
+                   " union U1 { Dummy }\n");
+      checkErrorIn("union 'U1' already defined.", 3, 2,
+                   "table U1 { c:int; }\n"
+                   "union U2 { Dummy }\n"
+                   " union U1 { Dummy }\n");
+      checkErrorIn("union 'U1' already defined.", 3, 2,
+                   "enum U1 { c }\n"
+                   "union U2 { Dummy }\n"
+                   " union U1 { Dummy }\n");
+      checkErrorIn("Empty union 'U2'.", 1, 4, "   union U2 {}");
+      checkErrorIn("union entry 'B' already defined for 'U2'.", 2, 19,
+                   "table B{a:int;}\n"
+                   "union U2 {B,Dummy,B}");
+      checkErrorIn("Unknown table 'xxx'.", 1, 11, "union T1 {xxx, Dummy}");
+    }
+
+    SECTION("unions allowed as table member")
+    {
+      checkNoErrorIn(
+          "union U { T, Dummy }\n"
+          "table T { \n"
+          "  x:U; \n"
+          "  y:[U];\n"
+          "  z:shared U;\n"
+          "}");
+    }
   }
 
   SECTION("wrong default values")

--- a/test/tabletypes.h
+++ b/test/tabletypes.h
@@ -18,6 +18,14 @@ struct TableB;
 struct TableD;
 struct TableC;
 
+template<typename T> bool operator==(const std::weak_ptr<T> &l, const std::weak_ptr<T> &r) {
+  return l.lock() == r.lock();
+}
+
+template<typename T> bool operator!=(const std::weak_ptr<T> &l, const std::weak_ptr<T> &r) {
+  return l.lock() != r.lock();
+}
+
 struct TableA {
   std::string name;
   std::unique_ptr<TableD> d1;
@@ -34,6 +42,24 @@ struct TableA {
     , d2(d2_)
   {}
 
+  friend bool operator==(const TableA&l, const TableA&r) {
+    return 
+      l.name == r.name
+      && l.d1 == r.d1
+      && l.d2 == r.d2
+      && l.d3 == r.d3
+      && l.d4 == r.d4;
+  }
+
+  friend bool operator!=(const TableA&l, const TableA&r) {
+    return 
+      l.name != r.name
+      || l.d1 != r.d1
+      || l.d2 != r.d2
+      || l.d3 != r.d3
+      || l.d4 != r.d4;
+  }
+
 private:
   unsigned int io_counter_{0};
   friend struct TableC_io;
@@ -43,6 +69,16 @@ struct TableB {
   std::string name;
 
   TableB() = default;
+
+  friend bool operator==(const TableB&l, const TableB&r) {
+    return 
+      l.name == r.name;
+  }
+
+  friend bool operator!=(const TableB&l, const TableB&r) {
+    return 
+      l.name != r.name;
+  }
 
 private:
   unsigned int io_counter_{0};
@@ -54,6 +90,18 @@ struct TableD {
   std::shared_ptr<TableA> a;
 
   TableD() = default;
+
+  friend bool operator==(const TableD&l, const TableD&r) {
+    return 
+      l.name == r.name
+      && l.a == r.a;
+  }
+
+  friend bool operator!=(const TableD&l, const TableD&r) {
+    return 
+      l.name != r.name
+      || l.a != r.a;
+  }
 
 private:
   unsigned int io_counter_{0};
@@ -71,73 +119,25 @@ struct TableC {
   TableC(std::vector<std::unique_ptr<TableA>> c_)
     : c(std::move(c_))
   {}
+
+  friend bool operator==(const TableC&l, const TableC&r) {
+    return 
+      l.a == r.a
+      && l.b == r.b
+      && l.c == r.c
+      && l.d == r.d
+      && l.e == r.e;
+  }
+
+  friend bool operator!=(const TableC&l, const TableC&r) {
+    return 
+      l.a != r.a
+      || l.b != r.b
+      || l.c != r.c
+      || l.d != r.d
+      || l.e != r.e;
+  }
 };
-
-template<typename T> bool operator==(const std::weak_ptr<T> &l, const std::weak_ptr<T> &r) {
-  return l.lock() == r.lock();
-}
-
-template<typename T> bool operator!=(const std::weak_ptr<T> &l, const std::weak_ptr<T> &r) {
-  return l.lock() != r.lock();
-}
-
-bool operator==(const TableA&l, const TableA&r) {
-  return 
-    l.name == r.name
-    && l.d1 == r.d1
-    && l.d2 == r.d2
-    && l.d3 == r.d3
-    && l.d4 == r.d4;
-}
-
-bool operator!=(const TableA&l, const TableA&r) {
-  return 
-    l.name != r.name
-    || l.d1 != r.d1
-    || l.d2 != r.d2
-    || l.d3 != r.d3
-    || l.d4 != r.d4;
-}
-
-bool operator==(const TableB&l, const TableB&r) {
-  return 
-    l.name == r.name;
-}
-
-bool operator!=(const TableB&l, const TableB&r) {
-  return 
-    l.name != r.name;
-}
-
-bool operator==(const TableD&l, const TableD&r) {
-  return 
-    l.name == r.name
-    && l.a == r.a;
-}
-
-bool operator!=(const TableD&l, const TableD&r) {
-  return 
-    l.name != r.name
-    || l.a != r.a;
-}
-
-bool operator==(const TableC&l, const TableC&r) {
-  return 
-    l.a == r.a
-    && l.b == r.b
-    && l.c == r.c
-    && l.d == r.d
-    && l.e == r.e;
-}
-
-bool operator!=(const TableC&l, const TableC&r) {
-  return 
-    l.a != r.a
-    || l.b != r.b
-    || l.c != r.c
-    || l.d != r.d
-    || l.e != r.e;
-}
 
 struct TableC_io {
 private:

--- a/test/tabletypes_tests.cpp
+++ b/test/tabletypes_tests.cpp
@@ -44,18 +44,20 @@ TEST_CASE("TableType test", "[output, table]")
 
   SECTION("reading whats written with shared data")
   {
-    Scope::TableC c;
-    c.a.emplace_back();
-    c.a.front().name = "TableA";
-    c.a.front().d1.reset(new Scope::TableD());
-    c.a.front().d1->name = "TableD_1";
-    c.a.front().d3 = std::make_shared<Scope::TableD>();
-    c.a.front().d3->name = "TableD_3";
-    c.a.front().d2 = c.a.front().d3;
-    c.a.front().d4 = c.a.front().d3;
-
     std::stringstream sOut;
-    Scope::TableC_io().WriteTableC(sOut, c);
+    {
+      Scope::TableC c;
+      c.a.emplace_back();
+      c.a.front().name = "TableA";
+      c.a.front().d1.reset(new Scope::TableD());
+      c.a.front().d1->name = "TableD_1";
+      c.a.front().d3 = std::make_shared<Scope::TableD>();
+      c.a.front().d3->name = "TableD_3";
+      c.a.front().d2 = c.a.front().d3;
+      c.a.front().d4 = c.a.front().d3;
+
+      Scope::TableC_io().WriteTableC(sOut, c);
+    }
 
     const auto buffer = sOut.str();
     std::stringstream sIn(buffer);
@@ -82,18 +84,21 @@ TEST_CASE("TableType test", "[output, table]")
 
   SECTION("reading whats written with shared data and cross releation ship")
   {
-    Scope::TableC c;
-    c.a.emplace_back();
-    c.a.front().name = "TableA";
-    c.a.front().d3 = std::make_shared<Scope::TableD>();
-    c.a.front().d3->name = "TableD_3";
-    c.a.front().d3->a = std::make_shared<Scope::TableA>();
-    c.a.front().d3->a->d2 = c.a.front().d3;
-    c.a.front().d3->a->d3 = c.a.front().d3;
-    c.a.front().d3->a->d4 = c.a.front().d3;
-
     std::stringstream sOut;
-    Scope::TableC_io().WriteTableC(sOut, c);
+
+    {
+      Scope::TableC c;
+      c.a.emplace_back();
+      c.a.front().name = "TableA";
+      c.a.front().d3 = std::make_shared<Scope::TableD>();
+      c.a.front().d3->name = "TableD_3";
+      c.a.front().d3->a = std::make_shared<Scope::TableA>();
+      c.a.front().d3->a->d2 = c.a.front().d3;
+      c.a.front().d3->a->d3 = c.a.front().d3;
+      c.a.front().d3->a->d4 = c.a.front().d3;
+
+      Scope::TableC_io().WriteTableC(sOut, c);
+    }
 
     const auto buffer = sOut.str();
     std::stringstream sIn(buffer);
@@ -118,17 +123,18 @@ TEST_CASE("TableType test", "[output, table]")
 
   SECTION("reading whats written with shared data in vectors")
   {
-    Scope::TableC c;
-    c.c.emplace_back(new Scope::TableA);
-    c.c.back()->name = "TableA_c";
-    c.d.emplace_back(new Scope::TableB);
-    c.d.back()->name = "TableB_d";
-    c.d.push_back(c.d.front());
-    c.e.push_back(c.d.front());
-    c.e.push_back(c.d.front());
-
     std::stringstream sOut;
-    Scope::TableC_io().WriteTableC(sOut, c);
+    {
+      Scope::TableC c;
+      c.c.emplace_back(new Scope::TableA);
+      c.c.back()->name = "TableA_c";
+      c.d.emplace_back(new Scope::TableB);
+      c.d.back()->name = "TableB_d";
+      c.d.push_back(c.d.front());
+      c.e.push_back(c.d.front());
+      c.e.push_back(c.d.front());
+      Scope::TableC_io().WriteTableC(sOut, c);
+    }
 
     const auto buffer = sOut.str();
     std::stringstream sIn(buffer);

--- a/test/uniontypes.h
+++ b/test/uniontypes.h
@@ -16,6 +16,7 @@ struct AlwaysFalse : std::false_type {};
 struct A;
 struct B;
 struct Root;
+struct AB;
 
 struct A {
   std::string name;
@@ -73,6 +74,137 @@ bool operator!=(const Root&l, const Root&r) {
     l.a != r.a
     || l.b != r.b;
 }
+
+struct AB {
+  AB() = default;
+  AB(const AB &o) { _clone(o); }
+  AB& operator=(const AB &o) { _destroy(); _clone(o); return *this; }
+
+  AB(const A &v)
+    : _A(new A(v))
+    , _selection(_A_selection)
+  {}
+  AB(A &&v)
+    : _A(new A(std::forward<A>(v)))
+    , _selection(_A_selection)
+  {}
+  AB & operator=(const A &v) {
+    _destroy();
+    _A = new A(v);
+    _selection = _A_selection;
+    return *this;
+  }
+  AB & operator=(A &&v) {
+    _destroy();
+    _A = new A(std::forward<A>(v));
+    _selection = _A_selection;
+    return *this;
+  }
+
+  AB(const B &v)
+    : _B(new B(v))
+    , _selection(_B_selection)
+  {}
+  AB(B &&v)
+    : _B(new B(std::forward<B>(v)))
+    , _selection(_B_selection)
+  {}
+  AB & operator=(const B &v) {
+    _destroy();
+    _B = new B(v);
+    _selection = _B_selection;
+    return *this;
+  }
+  AB & operator=(B &&v) {
+    _destroy();
+    _B = new B(std::forward<B>(v));
+    _selection = _B_selection;
+    return *this;
+  }
+
+  ~AB() {
+    _destroy();
+  }
+
+  bool is_Defined() const noexcept { return _selection != no_selection; }
+  bool is_A() const noexcept { return _selection == _A_selection; }
+  const A & as_A() const noexcept { return *_A; }
+  A & as_A() { return *_A; }
+
+  bool is_B() const noexcept { return _selection == _B_selection; }
+  const B & as_B() const noexcept { return *_B; }
+  B & as_B() { return *_B; }
+
+  friend bool operator==(const AB&ab, const A &o) noexcept  { return ab.is_A() && ab.as_A() == o; }
+  friend bool operator==(const A &o, const AB&ab) noexcept  { return ab.is_A() && o == ab.as_A(); }
+  friend bool operator!=(const AB&ab, const A &o) noexcept  { return !ab.is_A() || ab.as_A() != o; }
+  friend bool operator!=(const A &o, const AB&ab) noexcept  { return !ab.is_A() || o != ab.as_A(); }
+
+  friend bool operator==(const AB&ab, const B &o) noexcept  { return ab.is_B() && ab.as_B() == o; }
+  friend bool operator==(const B &o, const AB&ab) noexcept  { return ab.is_B() && o == ab.as_B(); }
+  friend bool operator!=(const AB&ab, const B &o) noexcept  { return !ab.is_B() || ab.as_B() != o; }
+  friend bool operator!=(const B &o, const AB&ab) noexcept  { return !ab.is_B() || o != ab.as_B(); }
+
+  bool operator==(const AB &o) const noexcept
+  {
+    if (this == &o)
+      return true;
+    if (_selection != o._selection)
+      return false;
+    switch(_selection) {
+    case no_selection: while(false); /* hack for coverage tool */ return true;
+    case _A_selection: return *_A == *o._A;
+    case _B_selection: return *_B == *o._B;
+    }
+    return false; // without this line there is a msvc warning I do not understand.
+  }
+
+  bool operator!=(const AB &o) const noexcept
+  {
+    if (this == &o)
+      return false;
+    if (_selection != o._selection)
+      return true;
+    switch(_selection) {
+    case no_selection: while(false); /* hack for coverage tool */ return false;
+    case _A_selection: return *_A != *o._A;
+    case _B_selection: return *_B != *o._B;
+    }
+    return false; // without this line there is a msvc warning I do not understand.
+  }
+
+private:
+  void _clone(const AB &o) noexcept
+  {
+     _selection = o._selection;
+    switch(_selection) {
+    case no_selection: while(false); /* hack for coverage tool */ break;
+    case _A_selection: _A = new A(*o._A); break;
+    case _B_selection: _B = new B(*o._B); break;
+    }
+  }
+
+  void _destroy() noexcept {
+    switch(_selection) {
+    case no_selection: while(false); /* hack for coverage tool */ break;
+    case _A_selection: delete _A; break;
+    case _B_selection: delete _B; break;
+    }
+  }
+
+  union {
+    A * _A;
+    B * _B;
+  };
+
+  enum Selection_t {
+    no_selection,
+    _A_selection,
+    _B_selection,
+  };
+
+  Selection_t _selection{no_selection};
+};
 
 struct Root_io {
 private:

--- a/test/uniontypes.h
+++ b/test/uniontypes.h
@@ -15,8 +15,8 @@ struct AlwaysFalse : std::false_type {};
 
 struct A;
 struct B;
-struct Root;
 struct AB;
+struct Root;
 
 template<typename T> bool operator==(const std::weak_ptr<T> &l, const std::weak_ptr<T> &r) {
   return l.lock() == r.lock();
@@ -61,43 +61,6 @@ struct B {
   friend bool operator!=(const B&l, const B&r) {
     return 
       l.size != r.size;
-  }
-};
-
-struct Root {
-  A a;
-  B b;
-  std::shared_ptr<AB> c;
-  std::weak_ptr<AB> cw;
-  std::unique_ptr<AB> d;
-  std::vector<AB> e;
-  std::unique_ptr<AB> empty;
-  std::unique_ptr<AB> null;
-
-  Root() = default;
-
-  friend bool operator==(const Root&l, const Root&r) {
-    return 
-      l.a == r.a
-      && l.b == r.b
-      && l.c == r.c
-      && l.cw == r.cw
-      && l.d == r.d
-      && l.e == r.e
-      && l.empty == r.empty
-      && l.null == r.null;
-  }
-
-  friend bool operator!=(const Root&l, const Root&r) {
-    return 
-      l.a != r.a
-      || l.b != r.b
-      || l.c != r.c
-      || l.cw != r.cw
-      || l.d != r.d
-      || l.e != r.e
-      || l.empty != r.empty
-      || l.null != r.null;
   }
 };
 
@@ -244,6 +207,46 @@ private:
   friend struct Root_io;
 };
 
+struct Root {
+  A a;
+  B b;
+  std::shared_ptr<AB> c;
+  std::weak_ptr<AB> cw;
+  std::unique_ptr<AB> d;
+  std::vector<AB> e;
+  AB f;
+  std::unique_ptr<AB> empty;
+  std::unique_ptr<AB> null;
+
+  Root() = default;
+
+  friend bool operator==(const Root&l, const Root&r) {
+    return 
+      l.a == r.a
+      && l.b == r.b
+      && l.c == r.c
+      && l.cw == r.cw
+      && l.d == r.d
+      && l.e == r.e
+      && l.f == r.f
+      && l.empty == r.empty
+      && l.null == r.null;
+  }
+
+  friend bool operator!=(const Root&l, const Root&r) {
+    return 
+      l.a != r.a
+      || l.b != r.b
+      || l.c != r.c
+      || l.cw != r.cw
+      || l.d != r.d
+      || l.e != r.e
+      || l.f != r.f
+      || l.empty != r.empty
+      || l.null != r.null;
+  }
+};
+
 struct Root_io {
 private:
   unsigned int AB_count_{0};
@@ -362,28 +365,6 @@ private:
     Read(s, v.size);
   }
 
-  void Write(std::ostream &o, const Root &v) {
-    Write(o, v.a);
-    Write(o, v.b);
-    Write(o, v.c);
-    Write(o, v.cw);
-    Write(o, v.d);
-    Write(o, v.e);
-    Write(o, v.empty);
-    Write(o, v.null);
-  }
-
-  void Read(std::istream &s, Root &v) {
-    Read(s, v.a);
-    Read(s, v.b);
-    Read(s, v.c);
-    Read(s, v.cw);
-    Read(s, v.d);
-    Read(s, v.e);
-    Read(s, v.empty);
-    Read(s, v.null);
-  }
-
   void Write(std::ostream &o, const AB &v) {
     o.write(reinterpret_cast<const char*>(&v._selection), sizeof(AB::Selection_t));
     switch(v._selection) {
@@ -432,6 +413,30 @@ private:
     v.resize(size);
     for (auto &entry : v)
       Read(s, entry);
+  }
+
+  void Write(std::ostream &o, const Root &v) {
+    Write(o, v.a);
+    Write(o, v.b);
+    Write(o, v.c);
+    Write(o, v.cw);
+    Write(o, v.d);
+    Write(o, v.e);
+    Write(o, v.f);
+    Write(o, v.empty);
+    Write(o, v.null);
+  }
+
+  void Read(std::istream &s, Root &v) {
+    Read(s, v.a);
+    Read(s, v.b);
+    Read(s, v.c);
+    Read(s, v.cw);
+    Read(s, v.d);
+    Read(s, v.e);
+    Read(s, v.f);
+    Read(s, v.empty);
+    Read(s, v.null);
   }
 
 public:

--- a/test/uniontypes.h
+++ b/test/uniontypes.h
@@ -1,0 +1,172 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <ostream>
+#include <istream>
+#include <memory>
+#include <array>
+#include <type_traits>
+
+namespace UnionTypes {
+
+template<typename T>
+struct AlwaysFalse : std::false_type {};
+
+struct A;
+struct B;
+struct Root;
+
+struct A {
+  std::string name;
+
+  A() = default;
+  A(const std::string &name_)
+    : name(name_)
+  {}
+};
+
+struct B {
+  std::int64_t size{0};
+
+  B() = default;
+  B(const std::int64_t &size_)
+    : size(size_)
+  {}
+};
+
+struct Root {
+  A a;
+  B b;
+
+  Root() = default;
+};
+
+bool operator==(const A&l, const A&r) {
+  return 
+    l.name == r.name;
+}
+
+bool operator!=(const A&l, const A&r) {
+  return 
+    l.name != r.name;
+}
+
+bool operator==(const B&l, const B&r) {
+  return 
+    l.size == r.size;
+}
+
+bool operator!=(const B&l, const B&r) {
+  return 
+    l.size != r.size;
+}
+
+bool operator==(const Root&l, const Root&r) {
+  return 
+    l.a == r.a
+    && l.b == r.b;
+}
+
+bool operator!=(const Root&l, const Root&r) {
+  return 
+    l.a != r.a
+    || l.b != r.b;
+}
+
+struct Root_io {
+private:
+  template<typename T> void Write(std::ostream &, const T *) {
+    static_assert(AlwaysFalse<T>::value, "Something not implemented");
+  }
+
+  template<typename T> void Write(std::ostream &o, const T &v) {
+    o.write(reinterpret_cast<const char *>(&v), sizeof(T));
+  }
+
+  template<typename T> void Write(std::ostream &o, const std::vector<T> &v) {
+    Write(o, v.size());
+    o.write(reinterpret_cast<const char *>(v.data()), sizeof(T) * v.size());
+  }
+
+  template<typename T> void Write(std::ostream &, const std::shared_ptr<T> &) {
+    static_assert(AlwaysFalse<T>::value, "Something not implemented");
+  }
+
+  void Write(std::ostream &o, const std::string &v) {
+    Write(o, v.size());
+    o.write(v.data(), v.size());
+  }
+
+  template<typename T> void Read(std::istream &i, T &v) {
+    i.read(reinterpret_cast<char *>(&v), sizeof(T));
+  }
+
+  template<typename T> void Read(std::istream &, std::shared_ptr<T> &) {
+    static_assert(AlwaysFalse<T>::value, "Something not implemented");
+  }
+
+  template<typename T> void Read(std::istream &i, std::vector<T> &v) {
+    typename std::vector<T>::size_type s{0};
+    Read(i, s);
+    v.resize(s);
+    i.read(reinterpret_cast<char *>(v.data()), sizeof(T) * s);
+  }
+
+  void Read(std::istream &i, std::string &v) {
+    std::string::size_type s{0};
+    Read(i, s);
+    v.resize(s);
+    i.read(&v[0], s);
+  }
+
+  void Write(std::ostream &o, const A &v) {
+    Write(o, v.name);
+  }
+
+  void Read(std::istream &s, A &v) {
+    Read(s, v.name);
+  }
+
+  void Write(std::ostream &o, const B &v) {
+    Write(o, v.size);
+  }
+
+  void Read(std::istream &s, B &v) {
+    Read(s, v.size);
+  }
+
+  void Write(std::ostream &o, const Root &v) {
+    Write(o, v.a);
+    Write(o, v.b);
+  }
+
+  void Read(std::istream &s, Root &v) {
+    Read(s, v.a);
+    Read(s, v.b);
+  }
+
+public:
+  void WriteRoot(std::ostream &o, const Root &v) {
+
+    o.write("CORE", 4);
+    o.write("0.0", 3);
+    Write(o, v);
+  }
+
+  bool ReadRoot(std::istream &i, Root &v) {
+
+    std::string marker("0000");
+    i.read(&marker[0], 4);
+    if (marker != "CORE")
+      return false;
+    std::string version(3, '_');
+    i.read(&version[0], 3);
+    if (version != "0.0")
+      return false;
+    Read(i, v);
+    return true;
+  }
+
+};
+}

--- a/test/uniontypes_tests.cpp
+++ b/test/uniontypes_tests.cpp
@@ -6,9 +6,208 @@
 
 using namespace UnionTypes;
 
+A testA()
+{
+  return A("hello");
+}
+
+void checkA(const AB &ab)
+{
+  REQUIRE(ab.is_Defined());
+  REQUIRE(ab.is_A());
+  REQUIRE_NOTHROW(ab.as_A());
+  CHECK_FALSE(ab.is_B());
+  CHECK(ab.as_A().name == "hello");
+}
+
+B testB()
+{
+  return B(42);
+}
+void checkB(const AB &ab)
+{
+  REQUIRE(ab.is_Defined());
+  REQUIRE(ab.is_B());
+  REQUIRE_NOTHROW(ab.as_B());
+  CHECK(ab.as_B().size == 42);
+}
+
 TEST_CASE("case", "[tag]")
 {
-  SECTION("compare operations")
+  SECTION("Use union")
+  {
+    SECTION("default")
+    {
+      AB ab;
+      CHECK(!ab.is_Defined());
+    }
+
+    SECTION("construct copy")
+    {
+      const AB a = testA();
+      checkA(AB(a));
+      const AB b = testB();
+      checkB(AB(b));
+    }
+
+    SECTION("assignment")
+    {
+      AB ab;
+      const AB a = testA();
+      ab = a;
+      checkA(ab);
+
+      const AB b = testB();
+      ab = b;
+      checkB(ab);
+
+      AB xx;
+      ab = xx;
+      CHECK(!ab.is_Defined());
+    }
+
+    SECTION("construct sub types r-value ")
+    {
+      checkA(AB(testA()));
+      checkB(AB(testB()));
+    }
+
+    SECTION("construct sub types l-value ")
+    {
+      const A a = testA();
+      checkA(AB(a));
+
+      const B b = testB();
+      checkB(AB(b));
+    }
+
+    SECTION("Assignment sub types r-value")
+    {
+      AB ab;
+      ab = testA();
+      checkA(ab);
+
+      ab = testB();
+      checkB(ab);
+    }
+
+    SECTION("Assignment sub types l-value ")
+    {
+      AB ab;
+      const A a = testA();
+      ab = a;
+      checkA(ab);
+
+      const B b = testB();
+      ab = b;
+      checkB(ab);
+    }
+
+    SECTION("Assignment sub types l-value ")
+    {
+      AB ab = testA();
+      ab.as_A().name = "HALLO";
+      CHECK(AB(testA()) != ab);
+
+      ab = testB();
+      ab.as_B().size = 53;
+      CHECK(AB(testB()) != ab);
+    }
+
+    SECTION("compare equal")
+    {
+      AB n;
+      AB a = testA();
+      AB b = testB();
+
+      CHECK(n == n);
+      CHECK(n == AB());
+      CHECK(a == AB(testA()));
+      CHECK(b == AB(testB()));
+
+      CHECK_FALSE(a == n);
+      CHECK_FALSE(a == b);
+      CHECK_FALSE(n == b);
+    }
+
+    SECTION("compare not equal")
+    {
+      AB n;
+      AB a = testA();
+      AB b = testB();
+
+      CHECK_FALSE(n != n);
+      CHECK_FALSE(n != AB());
+      CHECK_FALSE(a != AB(testA()));
+      CHECK_FALSE(b != AB(testB()));
+
+      CHECK(a != n);
+      CHECK(a != b);
+      CHECK(n != b);
+    }
+
+    SECTION("compare equal subtype l r")
+    {
+      AB n;
+      AB a = testA();
+      AB b = testB();
+
+      CHECK(a == testA());
+      CHECK(b == testB());
+
+      CHECK_FALSE(n == testA());
+      CHECK_FALSE(n == testB());
+      CHECK_FALSE(a == testB());
+      CHECK_FALSE(b == testA());
+    }
+
+    SECTION("compare equal subtype r l")
+    {
+      AB n;
+      AB a = testA();
+      AB b = testB();
+
+      CHECK(testA() == a);
+      CHECK(testB() == b);
+
+      CHECK_FALSE(testA() == n);
+      CHECK_FALSE(testB() == n);
+      CHECK_FALSE(testB() == a);
+      CHECK_FALSE(testA() == b);
+    }
+
+    SECTION("compare not equal subtype l r")
+    {
+      AB n;
+      AB a = testA();
+      AB b = testB();
+
+      CHECK_FALSE(a != testA());
+      CHECK_FALSE(b != testB());
+
+      CHECK(n != testA());
+      CHECK(n != testB());
+      CHECK(a != testB());
+      CHECK(b != testA());
+    }
+
+    SECTION("compare not equal subtype l r")
+    {
+      AB n;
+      AB a = testA();
+      AB b = testB();
+
+      CHECK_FALSE(testA() != a);
+      CHECK_FALSE(testB() != b);
+
+      CHECK(testA() != n);
+      CHECK(testB() != n);
+      CHECK(testB() != a);
+      CHECK(testA() != b);
+    }
+  }
+
+  SECTION("general compare operations")
   {
     CHECK(A() == A());
     CHECK_FALSE(A() != A());

--- a/test/uniontypes_tests.cpp
+++ b/test/uniontypes_tests.cpp
@@ -1,0 +1,53 @@
+
+#define CATCH_CONFIG_FAST_COMPILE
+#include <sstream>
+#include "catch2/catch.hpp"
+#include "uniontypes.h"
+
+using namespace UnionTypes;
+
+TEST_CASE("case", "[tag]")
+{
+  SECTION("compare operations")
+  {
+    CHECK(A() == A());
+    CHECK_FALSE(A() != A());
+
+    CHECK(B() == B());
+    CHECK_FALSE(B() != B());
+
+    CHECK(Root() == Root());
+    CHECK_FALSE(Root() != Root());
+  }
+
+  SECTION("reading whats written")
+  {
+    Root root;
+    root.a = A("Hallo");
+    root.b = B(42);
+
+    Root rootIn;
+    CHECK_FALSE(root == rootIn);
+
+    std::stringstream sOut;
+    Root_io().WriteRoot(sOut, root);
+
+    const auto buffer = sOut.str();
+    std::stringstream sIn(buffer);
+
+    Root_io().ReadRoot(sIn, rootIn);
+
+    CHECK(root == rootIn);
+  }
+
+  SECTION("Reading fails with wrong data")
+  {
+    Root r;
+
+    std::istringstream s1("FALSE");
+    CHECK_FALSE(Root_io().ReadRoot(s1, r));
+
+    std::istringstream s2("COREfails");
+    CHECK_FALSE(Root_io().ReadRoot(s2, r));
+  }
+}


### PR DESCRIPTION
## fixes #1 
- add `Union` type to `Package` structure
- merge `Union`, `Table` and `Enum` into one union into Package *(following the CoreBuffer schema)*
  -> definition order from IDLs are preserved 
- parsing unions from IDL files
- add structure checks for unions 
- write unions as structures to cpp output *(with a lot of convenient)*
- update IDL documentation 